### PR TITLE
Restrict sampler to subtypes `AbstractHMCSampler` 

### DIFF
--- a/ext/JuliaBUGSAdvancedHMCExt.jl
+++ b/ext/JuliaBUGSAdvancedHMCExt.jl
@@ -18,7 +18,7 @@ using AdvancedHMC: Transition, stat
 function AbstractMCMC.bundle_samples(
     ts::Vector{<:Transition},
     logdensitymodel::AbstractMCMC.LogDensityModel{<:LogDensityProblemsAD.ADGradientWrapper},
-    sampler::AbstractMCMC.AbstractSampler,
+    sampler::AdvancedHMC.AbstractHMCSampler,
     state,
     chain_type::Type{Chains};
     discard_initial=0,


### PR DESCRIPTION
`bundle_samples` depends on AHMC-specific APIs, thus not generally applicable to other samplers like MH. We need a separate `BUGSAdvancedMH` extension to support MH samplers. 