### PR TITLE
Remove `Context`s for the sack of simplicity 

### DIFF
--- a/ext/JuliaBUGSAdvancedHMCExt.jl
+++ b/ext/JuliaBUGSAdvancedHMCExt.jl
@@ -4,8 +4,7 @@ using AbstractMCMC
 using AdvancedHMC
 using AdvancedHMC: Transition, stat
 using JuliaBUGS
-using JuliaBUGS:
-    AbstractBUGSModel, BUGSModel, Gibbs, find_generated_vars, evaluate!!
+using JuliaBUGS: AbstractBUGSModel, BUGSModel, Gibbs, find_generated_vars, evaluate!!
 using JuliaBUGS.BUGSPrimitives
 using JuliaBUGS.BangBang
 using JuliaBUGS.LogDensityProblems

--- a/ext/JuliaBUGSAdvancedHMCExt.jl
+++ b/ext/JuliaBUGSAdvancedHMCExt.jl
@@ -5,7 +5,7 @@ using AdvancedHMC
 using AdvancedHMC: Transition, stat
 using JuliaBUGS
 using JuliaBUGS:
-    AbstractBUGSModel, BUGSModel, Gibbs, find_generated_vars, LogDensityContext, evaluate!!
+    AbstractBUGSModel, BUGSModel, Gibbs, find_generated_vars, evaluate!!
 using JuliaBUGS.BUGSPrimitives
 using JuliaBUGS.BangBang
 using JuliaBUGS.LogDensityProblems

--- a/ext/JuliaBUGSAdvancedMHExt.jl
+++ b/ext/JuliaBUGSAdvancedMHExt.jl
@@ -3,7 +3,7 @@ module JuliaBUGSAdvancedMHExt
 using AbstractMCMC
 using AdvancedMH
 using JuliaBUGS
-using JuliaBUGS: BUGSModel, find_generated_vars, LogDensityContext, evaluate!!
+using JuliaBUGS: BUGSModel, find_generated_vars, evaluate!!
 using JuliaBUGS.BUGSPrimitives
 using JuliaBUGS.LogDensityProblems
 using JuliaBUGS.LogDensityProblemsAD

--- a/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/ext/JuliaBUGSMCMCChainsExt.jl
@@ -89,7 +89,7 @@ function JuliaBUGS.gen_chains(
     param_vals = []
     generated_quantities = []
     for i in axes(samples)[1]
-        evaluation_env = first(evaluate!!(model, LogDensityContext(), samples[i]))
+        evaluation_env = first(evaluate!!(model, samples[i]))
         push!(
             param_vals,
             [AbstractPPL.get(evaluation_env, param_var) for param_var in param_vars],

--- a/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/ext/JuliaBUGSMCMCChainsExt.jl
@@ -1,7 +1,7 @@
 module JuliaBUGSMCMCChainsExt
 
 using JuliaBUGS
-using JuliaBUGS: AbstractBUGSModel, find_generated_vars, LogDensityContext, evaluate!!
+using JuliaBUGS: AbstractBUGSModel, find_generated_vars, evaluate!!
 using JuliaBUGS.AbstractPPL
 using JuliaBUGS.BUGSPrimitives
 using JuliaBUGS.LogDensityProblems

--- a/src/gibbs.jl
+++ b/src/gibbs.jl
@@ -62,8 +62,8 @@ function gibbs_internal end
 
 function gibbs_internal(rng::Random.AbstractRNG, cond_model::BUGSModel, ::MHFromPrior)
     transformed_original = JuliaBUGS.getparams(cond_model)
-    values, logp = evaluate!!(cond_model, LogDensityContext(), transformed_original)
-    values_proposed, logp_proposed = evaluate!!(cond_model, SamplingContext())
+    values, logp = evaluate!!(cond_model, transformed_original)
+    values_proposed, logp_proposed = evaluate!!(rng, cond_model)
 
     if logp_proposed - logp > log(rand(rng))
         values = values_proposed

--- a/src/logdensityproblems.jl
+++ b/src/logdensityproblems.jl
@@ -1,5 +1,5 @@
 function LogDensityProblems.logdensity(model::AbstractBUGSModel, x::AbstractArray)
-    _, logp = evaluate!!(model, LogDensityContext(), x)
+    _, logp = evaluate!!(model, x)
     return logp
 end
 

--- a/test/graphs.jl
+++ b/test/graphs.jl
@@ -66,10 +66,8 @@ mb_logp = begin
 end
 
 # order: b, l, c, a
-@test mb_logp ≈ evaluate!!(cond_model, JuliaBUGS.LogDensityContext(), [c_value])[2] rtol =
-    1e-8
+@test mb_logp ≈ evaluate!!(cond_model, [c_value])[2] rtol = 1e-8
 
-# test LogDensityContext
 @test begin
     logp = 0
     logp += logpdf(dnorm(1.0, 3.0), 1.0) # a, where f = 1.0
@@ -80,9 +78,7 @@ end
     logp += logpdf(dnorm(2.0, 1.0), 4.0) # d, where g = 2.0
     logp += logpdf(dnorm(4.0, 4.0), 5.0) # e, where h = 4.0
     logp
-end ≈ evaluate!!(
-    model, JuliaBUGS.LogDensityContext(), [-2.0, 4.0, 3.0, 2.0, 1.0, 4.0, 5.0]
-)[2] atol = 1e-8
+end ≈ evaluate!!(model, [-2.0, 4.0, 3.0, 2.0, 1.0, 4.0, 5.0])[2] atol = 1e-8
 
 # AuxiliaryNodeInfo
 test_model = @bugs begin

--- a/test/log_density.jl
+++ b/test/log_density.jl
@@ -1,6 +1,6 @@
 # TODO: make this available in JuliaBUGS
 function _logjoint(model::JuliaBUGS.BUGSModel)
-    return JuliaBUGS.evaluate!!(model, JuliaBUGS.DefaultContext())[2]
+    return JuliaBUGS.evaluate!!(model)[2]
 end
 
 @testset "Log density" begin


### PR DESCRIPTION
The three evaluation functions for `BUGSModel` can be distinguished without `Context`s. 

This PR removes them, as needs arise, we can add them back.