### PR TITLE
Mote performance improvement to log density evaluation

### DIFF
--- a/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/ext/JuliaBUGSMCMCChainsExt.jl
@@ -84,7 +84,7 @@ function JuliaBUGS.gen_chains(
     g = model.g
 
     generated_vars = find_generated_vars(g)
-    generated_vars = [v for v in model.sorted_nodes if v in generated_vars] # keep the order
+    generated_vars = [v for v in model.eval_cache.sorted_nodes if v in generated_vars] # keep the order
 
     param_vals = []
     generated_quantities = []

--- a/test/graphs.jl
+++ b/test/graphs.jl
@@ -47,11 +47,11 @@ c = @varname c
 cond_model = AbstractPPL.condition(model, setdiff(model.parameters, [c]))
 # tests for MarkovBlanketBUGSModel constructor
 @test cond_model.parameters == [c]
-@test Set(Symbol.(cond_model.sorted_nodes)) == Set([:l, :a, :b, :f, :c])
+@test Set(Symbol.(cond_model.eval_cache.sorted_nodes)) == Set([:l, :a, :b, :f, :c])
 
 decond_model = AbstractPPL.decondition(cond_model, [a, l])
 @test Set(Symbol.(decond_model.parameters)) == Set([:a, :c, :l])
-@test Set(Symbol.(decond_model.sorted_nodes)) ==
+@test Set(Symbol.(decond_model.eval_cache.sorted_nodes)) ==
     Set([:l, :b, :f, :a, :d, :e, :c, :h, :g, :i])
 
 c_value = 4.0


### PR DESCRIPTION
This remove another performance bottleneck: `getindex` from MetaGraph, by storing the data in arrays.