### PR TITLE
Further improve performance of logdensity evaluation

### DIFF
--- a/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/ext/JuliaBUGSMCMCChainsExt.jl
@@ -84,7 +84,9 @@ function JuliaBUGS.gen_chains(
     g = model.g
 
     generated_vars = find_generated_vars(g)
-    generated_vars = [v for v in model.flattened_graph_node_data.sorted_nodes if v in generated_vars] # keep the order
+    generated_vars = [
+        v for v in model.flattened_graph_node_data.sorted_nodes if v in generated_vars
+    ] # keep the order
 
     param_vals = []
     generated_quantities = []

--- a/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/ext/JuliaBUGSMCMCChainsExt.jl
@@ -84,7 +84,7 @@ function JuliaBUGS.gen_chains(
     g = model.g
 
     generated_vars = find_generated_vars(g)
-    generated_vars = [v for v in model.eval_cache.sorted_nodes if v in generated_vars] # keep the order
+    generated_vars = [v for v in model.flattened_graph_node_data.sorted_nodes if v in generated_vars] # keep the order
 
     param_vals = []
     generated_quantities = []

--- a/src/compiler_pass.jl
+++ b/src/compiler_pass.jl
@@ -753,11 +753,11 @@ function make_function_expr(
             Symbol("__", String(lhs.args[1]), "_", join(lhs.args[2:end], "_"), "__")
         end
 
-        return args, MacroTools.@q function $func_name(; $(arg_exprs...))
+        return args, MacroTools.@q function $func_name($(arg_exprs...))
             return $(expr)
         end
     else
-        return return args, MacroTools.@q function (; $(arg_exprs...))
+        return args, MacroTools.@q function ($(arg_exprs...))
             return $(expr)
         end
     end

--- a/src/gibbs.jl
+++ b/src/gibbs.jl
@@ -32,7 +32,8 @@ function AbstractMCMC.step(
         conditioned_model = AbstractPPL.condition(
             model, variable_to_condition_on, model.evaluation_env
         )
-        cached_eval_caches[variable_to_condition_on] = conditioned_model.eval_cache
+        cached_eval_caches[variable_to_condition_on] =
+            conditioned_model.flattened_graph_node_data
     end
     param_values = JuliaBUGS.getparams(model)
     return param_values, GibbsState(param_values, conditioning_schedule, cached_eval_caches)

--- a/src/model.jl
+++ b/src/model.jl
@@ -387,7 +387,8 @@ function AbstractPPL.decondition(model::BUGSModel, var_group::Vector{<:VarName})
         markov_blanket(base_model.g, new_parameters), new_parameters
     )
     sorted_blanket_with_vars = filter(
-        vn -> vn in markov_blanket_with_vars, base_model.flattened_graph_node_data.sorted_nodes
+        vn -> vn in markov_blanket_with_vars,
+        base_model.flattened_graph_node_data.sorted_nodes,
     )
 
     new_model = BUGSModel(

--- a/src/model.jl
+++ b/src/model.jl
@@ -379,8 +379,8 @@ function AbstractPPL.decondition(model::BUGSModel, var_group::Vector{<:VarName})
     base_model = model.base_model isa Nothing ? model : model.base_model
 
     new_parameters = [
-        v for
-        v in base_model.flattened_graph_node_data.sorted_nodes if v in union(model.parameters, var_group)
+        v for v in base_model.flattened_graph_node_data.sorted_nodes if
+        v in union(model.parameters, var_group)
     ] # keep the order
 
     markov_blanket_with_vars = union(

--- a/src/model.jl
+++ b/src/model.jl
@@ -76,39 +76,39 @@ struct BUGSModel{
     base_model::base_model_T
 end
 
-function Base.show(io::IO, m::BUGSModel)
-    if m.transformed
+function Base.show(io::IO, model::BUGSModel)
+    if model.transformed
         println(
             io,
-            "BUGSModel (transformed, with dimension $(m.transformed_param_length)):",
+            "BUGSModel (transformed, with dimension $(model.transformed_param_length)):",
             "\n",
         )
     else
         println(
             io,
-            "BUGSModel (untransformed, with dimension $(m.untransformed_param_length)):",
+            "BUGSModel (untransformed, with dimension $(model.untransformed_param_length)):",
             "\n",
         )
     end
     println(io, "  Model parameters:")
-    println(io, "    ", join(m.parameters, ", "), "\n")
+    println(io, "    ", join(model.parameters, ", "), "\n")
     println(io, "  Variable values:")
-    return println(io, "$(m.evaluation_env)")
+    return println(io, "$(model.evaluation_env)")
 end
 
 """
-    parameters(m::BUGSModel)
+    parameters(model::BUGSModel)
 
 Return a vector of `VarName` containing the names of the model parameters (unobserved stochastic variables).
 """
-parameters(m::BUGSModel) = m.parameters
+parameters(model::BUGSModel) = model.parameters
 
 """
-    variables(m::BUGSModel)
+    variables(model::BUGSModel)
 
 Return a vector of `VarName` containing the names of all the variables in the model.
 """
-variables(m::BUGSModel) = collect(labels(m.g))
+variables(model::BUGSModel) = collect(labels(model.g))
 
 @generated function prepare_arg_values(
     ::Val{args}, evaluation_env::NamedTuple, loop_vars::NamedTuple{lvars}

--- a/test/graphs.jl
+++ b/test/graphs.jl
@@ -47,11 +47,12 @@ c = @varname c
 cond_model = AbstractPPL.condition(model, setdiff(model.parameters, [c]))
 # tests for MarkovBlanketBUGSModel constructor
 @test cond_model.parameters == [c]
-@test Set(Symbol.(cond_model.eval_cache.sorted_nodes)) == Set([:l, :a, :b, :f, :c])
+@test Set(Symbol.(cond_model.flattened_graph_node_data.sorted_nodes)) ==
+    Set([:l, :a, :b, :f, :c])
 
 decond_model = AbstractPPL.decondition(cond_model, [a, l])
 @test Set(Symbol.(decond_model.parameters)) == Set([:a, :c, :l])
-@test Set(Symbol.(decond_model.eval_cache.sorted_nodes)) ==
+@test Set(Symbol.(decond_model.flattened_graph_node_data.sorted_nodes)) ==
     Set([:l, :b, :f, :a, :d, :e, :c, :h, :g, :i])
 
 c_value = 4.0


### PR DESCRIPTION
A source of type instability is the `prepare_arg_values`. This PR removes this function by modifying node functions to take `evaluation_env` directly and unpack within node functions, thus save the lookup and constructing keyword arguments step.