### PR TITLE
Add ISSUE template for DoodleBUGS

### DIFF
--- a/.github/ISSUE_TEMPLATE/doodlebugs.md
+++ b/.github/ISSUE_TEMPLATE/doodlebugs.md
@@ -1,0 +1,10 @@
+---
+name: DoodleBUGS
+about: DoodleBUGS Issue Template
+title: 'DoodleBUGS: '
+labels: DoodleBUGS
+assignees: shravanngoswamii
+
+---
+
+


### PR DESCRIPTION
I will soon add DoodleBUGS code in this repo, so It's good to have this issue template for keeping DoodleBUGS issues separate!