### PR TITLE
Update JuliaBUGS/docs/Project.toml

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -14,6 +14,7 @@ on:
       - 'JuliaBUGS/docs/**'
       - 'JuliaBUGS/src/**'
       - '.github/workflows/Docs.yml'
+  workflow_dispatch:
 
 concurrency:
   # Skip intermediate builds: always.

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 *.jl.*.cov
 
 # Documentation build artifacts
-docs/build/
-docs/site/
+JuliaBUGS/docs/build/
+JuliaBUGS/docs/site/
 
 # Julia dependency lockfile - auto-generated
 Manifest.toml

--- a/JuliaBUGS/docs/Project.toml
+++ b/JuliaBUGS/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+JuliaBUGS = "ba9fb4c0-828e-4473-b6a1-cd2560fee5bf"
 MetaGraphsNext = "fa8bd995-216d-47f1-8a91-f3b68fbeb377"
 
 [compat]

--- a/JuliaBUGS/docs/Project.toml
+++ b/JuliaBUGS/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 MetaGraphsNext = "fa8bd995-216d-47f1-8a91-f3b68fbeb377"
 
 [compat]
-Documenter = "0.27"
+Documenter = "1.14"

--- a/JuliaBUGS/docs/make.jl
+++ b/JuliaBUGS/docs/make.jl
@@ -5,7 +5,7 @@ using JuliaBUGS.BUGSPrimitives
 
 makedocs(;
     sitename="JuliaBUGS.jl",
-    warnonly = [:cross_references, :doctest],
+    warnonly=[:cross_references, :doctest],
     pages=[
         "Home" => "index.md",
         "Example" => "example.md",

--- a/JuliaBUGS/docs/make.jl
+++ b/JuliaBUGS/docs/make.jl
@@ -5,6 +5,7 @@ using JuliaBUGS.BUGSPrimitives
 
 makedocs(;
     sitename="JuliaBUGS.jl",
+    warnonly = [:cross_references, :doctest],
     pages=[
         "Home" => "index.md",
         "Example" => "example.md",


### PR DESCRIPTION
Monorepo packages are prefixed with folder name so tag documentation build requires `tag_prefix` but it is not supported by old Documenter.jl versions.

https://github.com/TuringLang/JuliaBUGS.jl/blob/d032e614af5c2bfa8abf603ab8b03294754c5d1b/.github/workflows/Docs.yml#L41

Now the issues is that new Documenter.jl version is causing docs failure because we are calling Julia standard library functions in docs (I am not sure of this), I am assuming it looking at these functions
https://github.com/TuringLang/JuliaBUGS.jl/blob/d032e614af5c2bfa8abf603ab8b03294754c5d1b/JuliaBUGS/docs/src/api/functions.md?plain=1#L10C1-L31C1