### PR TITLE
Add an argument to `condition` function to skip generating and evaling log density function

### DIFF
--- a/JuliaBUGS/Project.toml
+++ b/JuliaBUGS/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaBUGS"
 uuid = "ba9fb4c0-828e-4473-b6a1-cd2560fee5bf"
-version = "0.10.1"
+version = "0.10.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/JuliaBUGS/src/model/Model.jl
+++ b/JuliaBUGS/src/model/Model.jl
@@ -19,6 +19,7 @@ include("abstractppl.jl")
 include("logdensityproblems.jl")
 
 export parameters, variables, initialize!, getparams, settrans, set_evaluation_mode
+export regenerate_log_density_function, set_observed_values!
 export evaluate_with_rng!!, evaluate_with_env!!, evaluate_with_values!!
 
 end # Model

--- a/JuliaBUGS/src/model/abstractppl.jl
+++ b/JuliaBUGS/src/model/abstractppl.jl
@@ -20,7 +20,7 @@ import AbstractPPL: condition, decondition, evaluate!!
 #######################
 
 """
-    condition(model::BUGSModel, conditioning_spec)
+    condition(model::BUGSModel, conditioning_spec; regenerate_log_density::Bool=true)
 
 Create a new model by conditioning on specified variables with given values.
 
@@ -135,7 +135,7 @@ julia> parameters(model_cond4)
  y
 ```
 """
-function condition(model::BUGSModel, conditioning_spec)
+function condition(model::BUGSModel, conditioning_spec; regenerate_log_density::Bool=true)
     # Parse and validate conditioning specification
     var_values = _parse_conditioning_spec(conditioning_spec, model)::Dict{<:VarName,<:Any}
     vars_to_condition = collect(keys(var_values))::Vector{<:VarName}
@@ -157,6 +157,7 @@ function condition(model::BUGSModel, conditioning_spec)
         new_graph,
         new_evaluation_env;
         base_model=isnothing(model.base_model) ? model : model.base_model,
+        regenerate_log_density=regenerate_log_density,
     )
 end
 
@@ -551,6 +552,7 @@ function _create_modified_model(
     new_graph::BUGSGraph,
     new_evaluation_env::NamedTuple;
     base_model=nothing,
+    regenerate_log_density::Bool=true,
 )
     # Create new graph evaluation data
     new_graph_evaluation_data = GraphEvaluationData(new_graph)
@@ -562,9 +564,15 @@ function _create_modified_model(
     )
 
     # Generate new log density function and update graph evaluation data
-    new_log_density_computation_function, updated_graph_evaluation_data = _regenerate_log_density_function(
-        model.model_def, new_graph, new_evaluation_env, new_graph_evaluation_data
-    )
+    new_log_density_computation_function, updated_graph_evaluation_data =
+        if regenerate_log_density
+            _regenerate_log_density_function(
+                model.model_def, new_graph, new_evaluation_env, new_graph_evaluation_data
+            )
+        else
+            # Skip regeneration (fast path): ensure stale code isn't used
+            nothing, new_graph_evaluation_data
+        end
 
     # Recompute mutable symbols for the new graph
     new_mutable_symbols = get_mutable_symbols(updated_graph_evaluation_data)
@@ -579,6 +587,12 @@ function _create_modified_model(
         :log_density_computation_function => new_log_density_computation_function,
         :mutable_symbols => new_mutable_symbols,
     )
+
+    # Force graph evaluation mode when skipping regeneration to avoid stale compiled code
+    if !regenerate_log_density
+        kwargs[:evaluation_mode] = UseGraph()
+        kwargs[:log_density_computation_function] = nothing
+    end
 
     # Add base_model if provided
     if !isnothing(base_model)
@@ -621,6 +635,62 @@ function _regenerate_log_density_function(
     else
         return nothing, graph_evaluation_data
     end
+end
+
+#######################
+# Observed Value Updates
+#######################
+
+"""
+    set_observed_values!(model::BUGSModel, obs::Dict{<:VarName,<:Any})
+
+Update values of observed stochastic variables without reconditioning or regenerating code.
+
+Validates that each variable exists in the model, is stochastic, and is currently observed.
+Updates the evaluation environment in place and returns the updated model.
+"""
+function set_observed_values!(model::BUGSModel, obs::Dict{<:VarName,<:Any})
+    new_env = model.evaluation_env
+    for (vn, val) in obs
+        if vn ∉ labels(model.g)
+            throw(ArgumentError("Variable $vn does not exist in the model"))
+        end
+        node_info = model.g[vn]
+        if !node_info.is_stochastic
+            throw(ArgumentError("Cannot update $vn: it is deterministic (logical)"))
+        end
+        if !node_info.is_observed
+            throw(ArgumentError("Cannot update $vn: it is not observed"))
+        end
+        new_env = BangBang.setindex!!(new_env, val, vn)
+    end
+    return BangBang.setproperty!!(model, :evaluation_env, new_env)
+end
+
+"""
+    regenerate_log_density_function(model::BUGSModel; force::Bool=false)
+
+Generate and attach a compiled log-density function for the model's current graph and evaluation environment.
+
+Does not change the evaluation mode. When `force=false`, preserves an existing compiled function; when `force=true`,
+overwrites it if a new one can be generated. Returns the updated model (or the original if generation is not possible).
+"""
+function regenerate_log_density_function(model::BUGSModel; force::Bool=false)
+    new_fn, updated_graph_eval_data = _regenerate_log_density_function(
+        model.model_def, model.g, model.evaluation_env, model.graph_evaluation_data
+    )
+    # Always refresh graph_evaluation_data from regeneration helper (it may refine ordering)
+    model = BangBang.setproperty!!(model, :graph_evaluation_data, updated_graph_eval_data)
+
+    if isnothing(new_fn)
+        # Cannot generate compiled function; leave as-is
+        return model
+    end
+
+    if force || isnothing(model.log_density_computation_function)
+        model = BangBang.setproperty!!(model, :log_density_computation_function, new_fn)
+    end
+    return model
 end
 
 #######################


### PR DESCRIPTION
## Motivation
`condition` currently regenerates the log-density function on every call, invoking MacroTools transforms and `eval`. This is too slow for hot loops. 

We want a fast path for repeated conditioning that:
- Avoids regeneration
- Lets users update observed values in-place without changing graph structure
- Allows explicit regeneration later to regain compiled performance when desired

## Summary of Changes
- `condition` now supports a fast path via a keyword flag:
  - `condition(model, conditioning_spec; regenerate_log_density::Bool=true)`
  - When `false`: skips regeneration, nulls the compiled function, and forces graph evaluation mode
- New helper for value updates without reconditioning:
  - `set_observed_values!(model, obs::Dict{<:VarName,<:Any})`
  - Updates evaluation environment values of already-observed stochastic variables in-place
  - Validates existence, stochasticity, and observation status
- New function to regenerate the compiled log-density function without changing the evaluation mode:
  - `regenerate_log_density_function(model; force=false)`
  - Re-generates for the model’s current graph + environment and refreshes graph evaluation data
- Exports added:
  - `set_observed_values!` and `regenerate_log_density_function` (from `Model` module)

## Tiny Benchmark for Sanity Check
with 
```julia
@bugs begin
    for i in 1:N
        x[i] ~ Normal(0, 1)
    end
    y ~ Normal(sum(x[:]), 1)
end
```

```
BenchmarkTools results (N=100, iters=200):
  Single condition: regular = 13.96 ms, fast = 0.15 ms, speedup ≈ 92.3x
  Loop conditioning: regular = 28139.5 ms, fast(update only) = 0.2 ms, speedup ≈ 112840.1x
```

Interpretation:
- Single call to `condition`: ~90x faster when skipping regeneration
- Hot loop: one fast `condition` + repeated `set_observed_values!` is ~1e5x faster than repeatedly reconditioning