### PR TITLE
Support `AdvancedMH` and `SliceSampling` samplers in `AbstractMCMC.sample`

### DIFF
--- a/JuliaBUGS/Project.toml
+++ b/JuliaBUGS/Project.toml
@@ -32,6 +32,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [weakdeps]
 AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
 AdvancedMH = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
+AdvancedSliceSampling = "b0b775d2-f41c-11e9-0b13-fac5bb326e55"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 GraphMakie = "1ecd5474-83a3-4783-bb4f-06765db800d2"
 GraphPlot = "a2cc645c-3eea-5389-862e-a155d0052231"
@@ -40,6 +41,7 @@ MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 [extensions]
 JuliaBUGSAdvancedHMCExt = ["AdvancedHMC", "MCMCChains"]
 JuliaBUGSAdvancedMHExt = ["AdvancedMH", "MCMCChains"]
+JuliaBUGSAdvancedSliceSamplingExt = ["AdvancedSliceSampling", "MCMCChains"]
 JuliaBUGSGraphMakieExt = ["GraphMakie", "GLMakie"]
 JuliaBUGSGraphPlotExt = "GraphPlot"
 JuliaBUGSMCMCChainsExt = "MCMCChains"
@@ -51,6 +53,7 @@ AbstractPPL = "0.14"
 Accessors = "0.1"
 AdvancedHMC = "0.6, 0.7, 0.8"
 AdvancedMH = "0.8"
+AdvancedSliceSampling = "0.1"
 BangBang = "0.4.1"
 Bijectors = "0.13, 0.14, 0.15.5"
 DifferentiationInterface = "0.7"

--- a/JuliaBUGS/ext/JuliaBUGSAdvancedSliceSamplingExt.jl
+++ b/JuliaBUGS/ext/JuliaBUGSAdvancedSliceSamplingExt.jl
@@ -1,7 +1,7 @@
-module JuliaBUGSAdvancedMHExt
+module JuliaBUGSAdvancedSliceSamplingExt
 
 using AbstractMCMC
-using AdvancedMH
+using AdvancedSliceSampling
 using ADTypes
 using JuliaBUGS
 using JuliaBUGS: BUGSModel, BUGSModelWithGradient, getparams, initialize!
@@ -15,13 +15,13 @@ import AbstractMCMC: step
 function JuliaBUGS.gibbs_internal(
     rng::Random.AbstractRNG,
     cond_model::BUGSModel,
-    sampler::AdvancedMH.MHSampler,
+    sampler::AdvancedSliceSampling.Sampler,
     state=nothing,
 )
     # Use BUGSModel directly as log density (no gradients needed)
     logdensitymodel = AbstractMCMC.LogDensityModel(cond_model)
 
-    # Take MH step
+    # Take slice sampling step
     if isnothing(state)
         t, s = AbstractMCMC.step(
             rng, logdensitymodel, sampler; initial_params=getparams(cond_model)
@@ -30,7 +30,7 @@ function JuliaBUGS.gibbs_internal(
         t, s = AbstractMCMC.step(rng, logdensitymodel, sampler, state)
     end
 
-    # Handle scalar parameters from some MH proposals
+    # Handle scalar parameters from slice sampling proposals
     params = !isa(t.params, AbstractArray) ? [t.params] : t.params
 
     # Update model and return evaluation environment
@@ -38,11 +38,11 @@ function JuliaBUGS.gibbs_internal(
     return updated_model.evaluation_env, s
 end
 
-# Direct AbstractMCMC.step support for BUGSModel with AdvancedMH samplers
+# Direct AbstractMCMC.step support for BUGSModel with SliceSampling samplers
 function step(
     rng::Random.AbstractRNG,
     model::BUGSModel,
-    sampler::AdvancedMH.MHSampler;
+    sampler::AdvancedSliceSampling.Sampler;
     kwargs...,
 )
     # Wrap BUGSModel as LogDensityModel and delegate to AbstractMCMC.step
@@ -50,11 +50,11 @@ function step(
     return step(rng, logdensitymodel, sampler; kwargs...)
 end
 
-# Subsequent step for BUGSModel with state (not typically used directly, but for completeness)
+# Subsequent step for BUGSModel with state
 function step(
     rng::Random.AbstractRNG,
     model::BUGSModel,
-    sampler::AdvancedMH.MHSampler,
+    sampler::AdvancedSliceSampling.Sampler,
     state;
     kwargs...,
 )
@@ -62,11 +62,11 @@ function step(
     return step(rng, logdensitymodel, sampler, state; kwargs...)
 end
 
-# Direct AbstractMCMC.step support for BUGSModelWithGradient with AdvancedMH samplers
+# Direct AbstractMCMC.step support for BUGSModelWithGradient with SliceSampling samplers
 function step(
     rng::Random.AbstractRNG,
     model::BUGSModelWithGradient,
-    sampler::AdvancedMH.MHSampler;
+    sampler::AdvancedSliceSampling.Sampler;
     kwargs...,
 )
     # Wrap BUGSModelWithGradient as LogDensityModel and delegate
@@ -78,7 +78,7 @@ end
 function step(
     rng::Random.AbstractRNG,
     model::BUGSModelWithGradient,
-    sampler::AdvancedMH.MHSampler,
+    sampler::AdvancedSliceSampling.Sampler,
     state;
     kwargs...,
 )
@@ -86,48 +86,10 @@ function step(
     return step(rng, logdensitymodel, sampler, state; kwargs...)
 end
 
-function JuliaBUGS.gibbs_internal(
-    rng::Random.AbstractRNG,
-    cond_model::BUGSModel,
-    sampler_tuple::Tuple{<:AdvancedMH.MHSampler,<:ADTypes.AbstractADType},
-    state=nothing,
-)
-    # Extract sampler and AD backend for gradient-based MH proposals
-    sampler, ad_backend = sampler_tuple
-    return _gibbs_internal_mh(rng, cond_model, sampler, ad_backend, state)
-end
-
-function _gibbs_internal_mh(
-    rng::Random.AbstractRNG, cond_model::BUGSModel, sampler, ad_backend, state
-)
-    # Create gradient model on-the-fly
-    ad_model = BUGSModelWithGradient(cond_model, ad_backend)
-    x = getparams(cond_model)
-    logdensitymodel = AbstractMCMC.LogDensityModel(ad_model)
-
-    # Take MH step with gradient information
-    if isnothing(state)
-        t, s = AbstractMCMC.step(
-            rng,
-            logdensitymodel,
-            sampler;
-            n_adapts=0,  # Disable adaptation within Gibbs
-            initial_params=x,
-        )
-    else
-        t, s = AbstractMCMC.step(rng, logdensitymodel, sampler, state; n_adapts=0)
-    end
-
-    # Handle scalar parameters and update model
-    params = !isa(t.params, AbstractArray) ? [t.params] : t.params
-    updated_model = initialize!(cond_model, params)
-    return updated_model.evaluation_env, s
-end
-
 function AbstractMCMC.bundle_samples(
-    ts::Vector{<:AdvancedMH.Transition},
-    logdensitymodel::AbstractMCMC.LogDensityModel{<:JuliaBUGS.BUGSModel},
-    sampler::AdvancedMH.MHSampler,
+    ts::Vector{<:AdvancedSliceSampling.SliceSamplingTransition},
+    logdensitymodel::AbstractMCMC.LogDensityModel{<:BUGSModel},
+    sampler::AdvancedSliceSampling.Sampler,
     state,
     chain_type::Type{Chains};
     discard_initial=0,
@@ -152,9 +114,9 @@ function AbstractMCMC.bundle_samples(
 end
 
 function AbstractMCMC.bundle_samples(
-    ts::Vector{<:AdvancedMH.Transition},
+    ts::Vector{<:AdvancedSliceSampling.SliceSamplingTransition},
     logdensitymodel::AbstractMCMC.LogDensityModel{<:BUGSModelWithGradient},
-    sampler::AdvancedMH.MHSampler,
+    sampler::AdvancedSliceSampling.Sampler,
     state,
     chain_type::Type{Chains};
     discard_initial=0,

--- a/JuliaBUGS/test/ext/JuliaBUGSAdvancedMHDirectSamplingExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSAdvancedMHDirectSamplingExt.jl
@@ -1,0 +1,50 @@
+@testset "AdvancedMH direct AbstractMCMC.sample" begin
+    model_def = @bugs begin
+        α ~ Beta(2, 2)
+        β ~ Normal(0, 1)
+        for i in 1:N
+            y[i] ~ Normal(α + β * x[i], 1)
+        end
+    end
+
+    N = 20
+    x_data = collect(range(-1, 1; length=N))
+    y_data = 0.5 .+ 0.3 .* x_data .+ 0.1 .* randn(N)
+    model = compile(model_def, (; N=N, x=x_data, y=y_data))
+
+    # Test direct AbstractMCMC.sample with StaticMH
+    rng = StableRNG(1234)
+    sampler = StaticMH([Normal(0, 0.1)])
+    
+    chain = Base.invokelatest(
+        AbstractMCMC.sample,
+        rng,
+        model,
+        sampler,
+        100;
+        progress=false,
+        chain_type=Chains
+    )
+
+    @test chain isa AbstractMCMC.AbstractChains
+    @test size(chain, 1) == 100  # 100 samples
+    @test size(chain, 2) >= 1  # At least one parameter column
+
+    # Test with RWMH
+    rng = StableRNG(1234)
+    D = 2  # Dimensionality of the model
+    sampler = RWMH(MvNormal(zeros(D), I))
+    
+    chain = Base.invokelatest(
+        AbstractMCMC.sample,
+        rng,
+        model,
+        sampler,
+        50;
+        progress=false,
+        chain_type=Chains
+    )
+
+    @test chain isa AbstractMCMC.AbstractChains
+    @test size(chain, 1) == 50  # 50 samples
+end

--- a/JuliaBUGS/test/ext/JuliaBUGSAdvancedSliceSamplingExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSAdvancedSliceSamplingExt.jl
@@ -1,0 +1,38 @@
+@testset "AdvancedSliceSampling direct AbstractMCMC.sample" begin
+    model_def = @bugs begin
+        μ ~ Normal(0, 10)
+        σ ~ HalfNormal(1)
+        for i in 1:N
+            y[i] ~ Normal(μ, σ)
+        end
+    end
+
+    N = 20
+    y_data = randn(N) .+ 2.0
+    model = compile(model_def, (; N=N, y=y_data))
+
+    # Test direct AbstractMCMC.sample with SliceSampling
+    rng = StableRNG(1234)
+    sampler = Slice()  # Default slice sampler
+    
+    chain = Base.invokelatest(
+        AbstractMCMC.sample,
+        rng,
+        model,
+        sampler,
+        100;
+        progress=false,
+        chain_type=Chains
+    )
+
+    @test chain isa AbstractMCMC.AbstractChains
+    @test size(chain, 1) == 100  # 100 samples
+    @test size(chain, 2) >= 2  # At least two parameters (μ and σ)
+
+    # Check that samples are in reasonable range
+    μ_samples = vec(chain[:μ].data)
+    σ_samples = vec(chain[:σ].data)
+    @test all(isfinite, μ_samples)
+    @test all(isfinite, σ_samples)
+    @test all(σ_samples .> 0)  # σ should be positive
+end

--- a/JuliaBUGS/test/runtests.jl
+++ b/JuliaBUGS/test/runtests.jl
@@ -97,13 +97,16 @@ const TEST_GROUPS = OrderedDict{String,Function}(
         include("independent_mh.jl")
         include("ext/JuliaBUGSAdvancedHMCExt.jl")
         include("ext/JuliaBUGSMCMCChainsExt.jl")
+        include("ext/JuliaBUGSAdvancedMHDirectSamplingExt.jl")
         include("model/auto_marginalization_sampling.jl")
     end,
     "callbacks" => () -> include("model/abstractmcmc.jl"),
     "inference_hmc" => () -> include("ext/JuliaBUGSAdvancedHMCExt.jl"),
     "inference_chains" => () -> include("ext/JuliaBUGSMCMCChainsExt.jl"),
     "inference_mh" => () -> include("independent_mh.jl"),
+    "inference_mh_direct" => () -> include("ext/JuliaBUGSAdvancedMHDirectSamplingExt.jl"),
     "inference_marginalization" => () -> include("model/auto_marginalization_sampling.jl"),
+    "inference_slice" => () -> include("ext/JuliaBUGSAdvancedSliceSamplingExt.jl"),
     "gibbs" => () -> include("gibbs.jl"),
     "parallel_sampling" => () -> include("parallel_sampling.jl"),
     "distributed_sampling" => () -> include("distributed_sampling.jl"),


### PR DESCRIPTION
- Add `step()` methods for `AdvancedMH.MHSampler` to enable direct `AbstractMCMC.sample` calls on `BUGSModel` and `BUGSModelWithGradient`
- Create new `JuliaBUGSAdvancedSliceSamplingExt.jl` extension for `SliceSampling` support
- Implement `gibbs_internal()` and `step()` methods for `SliceSampling` samplers
- Add `AdvancedSliceSampling` to `Project.toml` weakdeps and compat
- Add tests for direct `AdvancedMH.sample` and `SliceSampling.sample` usage'
- fixes #382
