### PR TITLE
fix: prevent DoodleBUGS global CSS from polluting host applications

### DIFF
--- a/DoodleBUGS/src/App.vue
+++ b/DoodleBUGS/src/App.vue
@@ -7,3 +7,24 @@ import Toast from 'primevue/toast'
   <MainLayout />
   <Toast position="top-center" />
 </template>
+
+<style>
+body {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  background-color: var(--theme-bg-canvas);
+  color: var(--theme-text-primary);
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-sm);
+  -webkit-font-smoothing: antialiased;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+}
+</style>

--- a/DoodleBUGS/src/DoodleWidget.vue
+++ b/DoodleBUGS/src/DoodleWidget.vue
@@ -1027,7 +1027,8 @@ watch(showNewGraphModal, (val) => {
 
       <div
         class="db-ui-overlay"
-        :class="{ 'db-dark-mode': isDarkMode,
+        :class="{
+          'db-dark-mode': isDarkMode,
           'db-widget-ready': widgetInitialized,
           'db-fullscreen': isFullScreen,
         }"

--- a/DoodleBUGS/src/DoodleWidget.vue
+++ b/DoodleBUGS/src/DoodleWidget.vue
@@ -267,7 +267,7 @@ const controlsStyle = computed(() => {
   const style: Record<string, string> = {
     position: 'absolute',
     zIndex: '1000',
-    display: 'flex',
+    display: 'db-flex',
     gap: '8px',
     pointerEvents: 'auto',
   }
@@ -1027,8 +1027,7 @@ watch(showNewGraphModal, (val) => {
 
       <div
         class="db-ui-overlay"
-        :class="{
-          'db-dark-mode': isDarkMode,
+        :class="{ 'db-dark-mode': isDarkMode,
           'db-widget-ready': widgetInitialized,
           'db-fullscreen': isFullScreen,
         }"
@@ -1043,9 +1042,9 @@ watch(showNewGraphModal, (val) => {
               :style="inlineLeftTriggerStyle"
               @click="handleSidebarContainerClick"
             >
-              <div class="db-sidebar-trigger-content gap-1">
+              <div class="db-sidebar-trigger-content db-gap-1">
                 <div
-                  class="grow flex items-center gap-2 overflow-hidden"
+                  class="grow db-flex db-items-center db-gap-2 overflow-hidden"
                   style="flex-grow: 1; overflow: hidden"
                 >
                   <span class="db-logo-text-minimized">
@@ -1055,7 +1054,7 @@ watch(showNewGraphModal, (val) => {
                     <span class="db-mobile-text">DoodleBUGS</span>
                   </span>
                 </div>
-                <div class="flex items-center shrink-0" style="flex-shrink: 0">
+                <div class="db-flex db-items-center shrink-0" style="flex-shrink: 0">
                   <button
                     v-tooltip.top="{
                       value: isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode',
@@ -1098,9 +1097,9 @@ watch(showNewGraphModal, (val) => {
               :style="inlineRightTriggerStyle"
               @click="uiStore.toggleRightSidebar()"
             >
-              <div class="db-sidebar-trigger-content gap-2">
+              <div class="db-sidebar-trigger-content db-gap-2">
                 <span class="db-sidebar-title-minimized">Inspector</span>
-                <div class="flex items-center">
+                <div class="db-flex db-items-center">
                   <div
                     v-tooltip.top="{
                       value: isModelValid ? 'Model is valid' : 'Model has validation issues',
@@ -1383,7 +1382,7 @@ watch(showNewGraphModal, (val) => {
             <h3>Create New Graph</h3>
           </template>
           <template #body>
-            <div class="flex flex-col gap-2">
+            <div class="db-flex db-flex-col db-gap-2">
               <div class="db-form-group">
                 <label for="new-graph-name">Graph Name</label>
                 <BaseInput

--- a/DoodleBUGS/src/assets/styles/global.css
+++ b/DoodleBUGS/src/assets/styles/global.css
@@ -110,24 +110,8 @@ html.db-dark-mode {
   --shadow-floating: 0 10px 30px -4px rgba(0, 0, 0, 0.6);
 }
 
-body {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-  background-color: var(--theme-bg-canvas);
-  color: var(--theme-text-primary);
-  font-family: var(--font-family-sans);
-  font-size: var(--font-size-sm);
-  -webkit-font-smoothing: antialiased;
-}
-
-#app {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  width: 100vw;
-  overflow: hidden;
-}
+/* Global body styles removed to prevent namespace pollution in host applications. 
+   These should be applied at the host level (e.g. App.vue) if needed. */
 
 /* Utility classes */
 .flex {

--- a/DoodleBUGS/src/assets/styles/global.css
+++ b/DoodleBUGS/src/assets/styles/global.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
 @import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css');
 @import './shared-ui.css';
 
@@ -110,77 +111,76 @@ html.db-dark-mode {
   --shadow-floating: 0 10px 30px -4px rgba(0, 0, 0, 0.6);
 }
 
-/* Global body styles removed to prevent namespace pollution in host applications. 
-   These should be applied at the host level (e.g. App.vue) if needed. */
+
 
 /* Utility classes */
-.flex {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .flex {
   display: flex;
 }
 
-.flex-col {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .flex-col {
   flex-direction: column;
 }
 
-.items-center {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .items-center {
   align-items: center;
 }
 
-.justify-center {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .justify-center {
   justify-content: center;
 }
 
-.justify-between {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .justify-between {
   justify-content: space-between;
 }
 
-.gap-1 {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .gap-1 {
   gap: 4px;
 }
 
-.gap-2 {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .gap-2 {
   gap: 8px;
 }
 
-.gap-3 {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .gap-3 {
   gap: 12px;
 }
 
-.p-2 {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .p-2 {
   padding: 8px;
 }
 
-.text-xs {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .text-xs {
   font-size: var(--font-size-xs);
 }
 
-.text-sm {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .text-sm {
   font-size: var(--font-size-sm);
 }
 
-.text-md {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .text-md {
   font-size: var(--font-size-md);
 }
 
-.font-bold {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .font-bold {
   font-weight: 600;
 }
 
-.w-full {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .w-full {
   width: 100%;
 }
 
-.h-full {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .h-full {
   height: 100%;
 }
 
 /* Custom Base Modal Responsive Width */
-.base-modal-responsive {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .base-modal-responsive {
   width: 50vw;
 }
 
 @media (max-width: 768px) {
-  .base-modal-responsive {
+  :is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .base-modal-responsive {
     width: 95vw !important;
   }
 }
@@ -236,7 +236,7 @@ html.db-dark-mode .cytoscape-container {
 }
 
 /* Glassmorphism Utility */
-.glass-panel {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .glass-panel {
   background: var(--theme-bg-panel-transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -245,24 +245,24 @@ html.db-dark-mode .cytoscape-container {
 }
 
 /* Debug Panel - Green Theme */
-.debug-panel {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .debug-panel {
   border-top-color: var(--theme-primary) !important;
   color: #fff !important;
 }
 
-.debug-header {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .debug-header {
   background: rgba(16, 185, 129, 0.2) !important;
   border-bottom-color: var(--theme-primary) !important;
   color: #fff !important;
 }
 
-.debug-btn {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .debug-btn {
   border-color: var(--theme-primary) !important;
   color: var(--theme-primary) !important;
   background: transparent !important;
 }
 
-.log-type.type-log {
+:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .log-type.type-log {
   color: var(--theme-primary) !important;
 }
 

--- a/DoodleBUGS/src/assets/styles/global.css
+++ b/DoodleBUGS/src/assets/styles/global.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
 @import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css');
 @import './shared-ui.css';
 
@@ -114,73 +113,73 @@ html.db-dark-mode {
 
 
 /* Utility classes */
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .flex {
+.db-flex {
   display: flex;
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .flex-col {
+.db-flex-col {
   flex-direction: column;
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .items-center {
+.db-items-center {
   align-items: center;
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .justify-center {
+.db-justify-center {
   justify-content: center;
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .justify-between {
+.db-justify-between {
   justify-content: space-between;
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .gap-1 {
+.db-gap-1 {
   gap: 4px;
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .gap-2 {
+.db-gap-2 {
   gap: 8px;
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .gap-3 {
+.db-gap-3 {
   gap: 12px;
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .p-2 {
+.db-p-2 {
   padding: 8px;
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .text-xs {
+.db-text-xs {
   font-size: var(--font-size-xs);
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .text-sm {
+.db-text-sm {
   font-size: var(--font-size-sm);
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .text-md {
+.db-text-md {
   font-size: var(--font-size-md);
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .font-bold {
+.db-font-bold {
   font-weight: 600;
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .w-full {
+.db-w-full {
   width: 100%;
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .h-full {
+.db-h-full {
   height: 100%;
 }
 
 /* Custom Base Modal Responsive Width */
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .base-modal-responsive {
+.db-base-modal-responsive {
   width: 50vw;
 }
 
 @media (max-width: 768px) {
-  :is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .base-modal-responsive {
+  .db-base-modal-responsive {
     width: 95vw !important;
   }
 }
@@ -236,7 +235,7 @@ html.db-dark-mode .cytoscape-container {
 }
 
 /* Glassmorphism Utility */
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .glass-panel {
+.db-glass-panel {
   background: var(--theme-bg-panel-transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -245,24 +244,24 @@ html.db-dark-mode .cytoscape-container {
 }
 
 /* Debug Panel - Green Theme */
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .debug-panel {
+.debug-panel {
   border-top-color: var(--theme-primary) !important;
   color: #fff !important;
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .debug-header {
+.debug-header {
   background: rgba(16, 185, 129, 0.2) !important;
   border-bottom-color: var(--theme-primary) !important;
   color: #fff !important;
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .debug-btn {
+.debug-btn {
   border-color: var(--theme-primary) !important;
   color: var(--theme-primary) !important;
   background: transparent !important;
 }
 
-:is(.db-widget-root, .db-ui-overlay, .db-sidebar-wrapper, .p-dialog) .log-type.type-log {
+.log-type.type-log {
   color: var(--theme-primary) !important;
 }
 

--- a/DoodleBUGS/src/assets/styles/global.css
+++ b/DoodleBUGS/src/assets/styles/global.css
@@ -265,3 +265,16 @@ html.db-dark-mode .cytoscape-container {
 .log-type.type-log {
   color: var(--theme-primary) !important;
 }
+
+/* Base styles for the DoodleWidget container */
+.db-widget-root {
+  background-color: var(--theme-bg-canvas);
+  color: var(--theme-text-primary);
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-sm);
+  -webkit-font-smoothing: antialiased;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}

--- a/DoodleBUGS/src/components/canvas/GraphCanvas.vue
+++ b/DoodleBUGS/src/components/canvas/GraphCanvas.vue
@@ -517,8 +517,7 @@ watch(
   <div
     ref="cyContainer"
     class="db-cytoscape-container"
-    :class="{
-      'db-grid-background': isGridEnabled && gridSize > 0,
+    :class="{ 'db-grid-background': isGridEnabled && gridSize > 0,
       'db-grid-lines': gridStyle === 'lines' && isGridEnabled && gridSize > 0,
       'db-grid-dots': gridStyle === 'dots' && isGridEnabled && gridSize > 0,
       'db-mode-add-node': currentMode === 'add-node' && !readOnly,

--- a/DoodleBUGS/src/components/canvas/GraphCanvas.vue
+++ b/DoodleBUGS/src/components/canvas/GraphCanvas.vue
@@ -517,7 +517,8 @@ watch(
   <div
     ref="cyContainer"
     class="db-cytoscape-container"
-    :class="{ 'db-grid-background': isGridEnabled && gridSize > 0,
+    :class="{
+      'db-grid-background': isGridEnabled && gridSize > 0,
       'db-grid-lines': gridStyle === 'lines' && isGridEnabled && gridSize > 0,
       'db-grid-dots': gridStyle === 'dots' && isGridEnabled && gridSize > 0,
       'db-mode-add-node': currentMode === 'add-node' && !readOnly,

--- a/DoodleBUGS/src/components/common/DropdownMenu.vue
+++ b/DoodleBUGS/src/components/common/DropdownMenu.vue
@@ -27,7 +27,7 @@ const onContentClick = (event: MouseEvent) => {
       <slot name="trigger"></slot>
     </div>
     <Popover ref="op">
-      <div class="flex flex-col min-w-[150px] py-1" @click="onContentClick">
+      <div class="db-flex db-flex-col min-w-[150px] py-1" @click="onContentClick">
         <slot name="content"></slot>
       </div>
     </Popover>

--- a/DoodleBUGS/src/components/layouts/GraphStyleModal.vue
+++ b/DoodleBUGS/src/components/layouts/GraphStyleModal.vue
@@ -211,7 +211,7 @@ const resetStyleSettings = () => {
                 max="1"
                 step="0.1"
                 v-model.number="tempNodeStyle.backgroundOpacity"
-                class="w-full"
+                class="db-w-full"
               />
             </div>
             <div class="db-grid-2" v-if="editingNodeType !== 'plate'">
@@ -310,7 +310,7 @@ const resetStyleSettings = () => {
                   max="1"
                   step="0.1"
                   v-model.number="tempEdgeStyle.labelBackgroundOpacity"
-                  class="w-full h-8"
+                  class="db-w-full h-8"
                 />
               </div>
             </div>

--- a/DoodleBUGS/src/components/layouts/LeftSidebar.vue
+++ b/DoodleBUGS/src/components/layouts/LeftSidebar.vue
@@ -118,7 +118,7 @@ const handleHeaderClick = () => {
       <span class="db-sidebar-title">
         {{ pinnedGraphTitle ? `DoodleBUGS / ${pinnedGraphTitle}` : 'DoodleBUGS' }}
       </span>
-      <div class="flex items-center ml-auto">
+      <div class="db-flex db-items-center ml-auto">
         <button
           v-tooltip.top="{
             value: isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode',
@@ -134,7 +134,7 @@ const handleHeaderClick = () => {
         </button>
         <div
           v-tooltip.top="{ value: 'Collapse Sidebar', showDelay: 0, hideDelay: 0 }"
-          class="flex items-center"
+          class="db-flex db-items-center"
           @mousedown.stop
           @touchstart.stop
           @click.stop="$emit('toggle-left-sidebar')"
@@ -172,7 +172,7 @@ const handleHeaderClick = () => {
                   class="db-examples-dropdown"
                 >
                   <template #option="{ option }">
-                    <div class="flex items-center gap-2">
+                    <div class="db-flex db-items-center db-gap-2">
                       <span>{{ option.name }}</span>
                     </div>
                   </template>
@@ -185,7 +185,7 @@ const handleHeaderClick = () => {
         <AccordionPanel value="view">
           <AccordionHeader><i class="fas fa-eye db-icon-12"></i> View Options</AccordionHeader>
           <AccordionContent>
-            <div class="db-menu-panel flex-col gap-3">
+            <div class="db-menu-panel db-flex-col db-gap-3">
               <div class="db-menu-row">
                 <label>Canvas Grid</label>
                 <ToggleSwitch
@@ -236,7 +236,7 @@ const handleHeaderClick = () => {
         <AccordionPanel value="help">
           <AccordionHeader><i class="fas fa-question-circle db-icon-12"></i> Help</AccordionHeader>
           <AccordionContent>
-            <div class="db-menu-panel flex-col gap-1">
+            <div class="db-menu-panel db-flex-col db-gap-1">
               <BaseButton type="ghost" class="db-menu-btn" @click="$emit('open-faq-modal')"
                 ><i class="fas fa-question"></i> FAQ</BaseButton
               >
@@ -259,7 +259,7 @@ const handleHeaderClick = () => {
             ><i class="fas fa-terminal db-icon-12"></i> Developer Tools</AccordionHeader
           >
           <AccordionContent>
-            <div class="db-menu-panel flex-col gap-3">
+            <div class="db-menu-panel db-flex-col db-gap-3">
               <div class="db-menu-row">
                 <label>Debug Console</label>
                 <ToggleSwitch

--- a/DoodleBUGS/src/components/layouts/MainLayout.vue
+++ b/DoodleBUGS/src/components/layouts/MainLayout.vue
@@ -569,9 +569,9 @@ onUnmounted(() => {
         class="db-collapsed-sidebar-trigger db-left-trigger"
         @click="handleSidebarContainerClick"
       >
-        <div class="db-sidebar-trigger-content gap-1">
+        <div class="db-sidebar-trigger-content db-gap-1">
           <div
-            class="grow flex items-center gap-2 overflow-hidden"
+            class="grow db-flex db-items-center db-gap-2 overflow-hidden"
             style="flex-grow: 1; overflow: hidden"
           >
             <span class="db-logo-text-minimized">
@@ -581,7 +581,7 @@ onUnmounted(() => {
               <span class="db-mobile-text">DoodleBUGS</span>
             </span>
           </div>
-          <div class="flex items-center shrink-0" style="flex-shrink: 0">
+          <div class="db-flex db-items-center shrink-0" style="flex-shrink: 0">
             <button
               v-tooltip.top="{
                 value: isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode',
@@ -637,9 +637,9 @@ onUnmounted(() => {
         class="db-collapsed-sidebar-trigger db-right"
         @click="toggleRightSidebar"
       >
-        <div class="db-sidebar-trigger-content gap-2">
+        <div class="db-sidebar-trigger-content db-gap-2">
           <span class="db-sidebar-title-minimized">Inspector</span>
-          <div class="flex items-center">
+          <div class="db-flex db-items-center">
             <div
               class="db-status-indicator db-validation-status"
               @click.stop="showValidationModal = true"
@@ -748,7 +748,7 @@ onUnmounted(() => {
         <h3>Create New Project</h3>
       </template>
       <template #body>
-        <div class="flex items-center gap-3">
+        <div class="db-flex db-items-center db-gap-3">
           <label style="min-width: 100px; font-weight: 500">Project Name:</label>
           <BaseInput
             v-model="newProjectName"
@@ -767,7 +767,7 @@ onUnmounted(() => {
         <h3>Create New Graph</h3>
       </template>
       <template #body>
-        <div class="flex flex-col gap-2">
+        <div class="db-flex db-flex-col db-gap-2">
           <div class="db-form-group">
             <label for="new-graph-name">Graph Name</label>
             <BaseInput

--- a/DoodleBUGS/src/components/layouts/RightSidebar.vue
+++ b/DoodleBUGS/src/components/layouts/RightSidebar.vue
@@ -83,7 +83,7 @@ const handleHeaderClick = () => {
     >
       <span class="db-sidebar-title">Inspector</span>
 
-      <div class="flex items-center ml-auto" @click.stop @mousedown.stop @touchstart.stop>
+      <div class="db-flex db-items-center ml-auto" @click.stop @mousedown.stop @touchstart.stop>
         <div
           v-tooltip.top="{
             value: isModelValid ? 'Model is valid' : 'Model has validation issues',
@@ -147,7 +147,7 @@ const handleHeaderClick = () => {
 
       <div
         v-tooltip.top="{ value: 'Collapse Sidebar', showDelay: 0, hideDelay: 0 }"
-        class="pointer-events-auto flex items-center ml-2"
+        class="pointer-events-auto db-flex db-items-center ml-2"
         @mousedown.stop
         @touchstart.stop
         @click.stop="$emit('toggle-right-sidebar')"
@@ -206,7 +206,7 @@ const handleHeaderClick = () => {
       />
 
       <div v-show="activeRightTab === 'export'" class="db-export-panel">
-        <div class="db-menu-panel flex-col gap-3">
+        <div class="db-menu-panel db-flex-col db-gap-3">
           <h5 class="db-section-title">Image Export</h5>
           <BaseButton type="ghost" class="db-menu-btn" @click="$emit('open-export-modal', 'png')"
             ><i class="fas fa-image"></i> PNG Image</BaseButton

--- a/DoodleBUGS/src/components/layouts/ValidationIssuesModal.vue
+++ b/DoodleBUGS/src/components/layouts/ValidationIssuesModal.vue
@@ -98,7 +98,7 @@ const copyLogs = () => {
       </div>
     </template>
     <template #footer>
-      <div class="w-full flex justify-end">
+      <div class="db-w-full db-flex justify-end">
         <BaseButton @click="copyLogs" type="secondary" v-if="errorsWithNodeNames.length > 0">
           <i v-if="copySuccess" class="fas fa-check"></i>
           <span v-else>Copy Logs</span>

--- a/DoodleBUGS/src/components/ui/BaseInput.vue
+++ b/DoodleBUGS/src/components/ui/BaseInput.vue
@@ -38,7 +38,7 @@ const handleUpdate = (val: string | null | undefined) => {
     @change="(e) => emit('change', e)"
     @input="(e) => emit('input', e)"
     @keyup.enter="(e) => emit('keyup.enter', e)"
-    class="w-full db-input-field"
+    class="db-w-full db-input-field"
   />
 </template>
 

--- a/DoodleBUGS/src/components/ui/BaseSelect.vue
+++ b/DoodleBUGS/src/components/ui/BaseSelect.vue
@@ -31,7 +31,7 @@ const emit = defineEmits(['update:modelValue', 'change'])
     class="w-auto db-select-field"
   >
     <template #value="slotProps">
-      <div v-if="slotProps.value" class="flex items-center">
+      <div v-if="slotProps.value" class="db-flex db-items-center">
         <slot name="value" :value="slotProps.value" :placeholder="slotProps.placeholder">
           {{
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
Removes body and #app global styles from `global.css` and moves them to `App.vue` so they do not leak into third-party host applications like Documenter.jl or other consumers of DoodleWidget.