### PR TITLE
DoodleBUGS: emit per-language code updates from the widget

### DIFF
--- a/DoodleBUGS/README.md
+++ b/DoodleBUGS/README.md
@@ -152,10 +152,15 @@ All props are optional:
 
 ### Events
 
-| Event          | Payload     | Description                                  |
-| -------------- | ----------- | -------------------------------------------- |
-| `state-update` | JSON string | Fires on any change. Contains complete state |
-| `code-update`  | string      | Fires when BUGS code changes                 |
+| Event               | Payload     | Description                                              |
+| ------------------- | ----------- | -------------------------------------------------------- |
+| `state-update`      | JSON string | Fires on any change. Contains complete state             |
+| `bugs-code-update`  | string      | Fires when the generated BUGS code changes               |
+| `stan-code-update`  | string      | Fires when the generated Stan code changes               |
+| `ready`             | JSON string | Fires once after mount with the initial state            |
+| `models-available`  | JSON string | Fires once with the list of built-in example model names |
+
+Both `bugs-code-update` and `stan-code-update` fire whenever the model changes, regardless of which language the user has visible in the code preview panel. Host applications that need one specific language should subscribe to the matching event.
 
 ### Saving to Backend
 

--- a/DoodleBUGS/README.md
+++ b/DoodleBUGS/README.md
@@ -152,13 +152,13 @@ All props are optional:
 
 ### Events
 
-| Event               | Payload     | Description                                              |
-| ------------------- | ----------- | -------------------------------------------------------- |
-| `state-update`      | JSON string | Fires on any change. Contains complete state             |
-| `bugs-code-update`  | string      | Fires when the generated BUGS code changes               |
-| `stan-code-update`  | string      | Fires when the generated Stan code changes               |
-| `ready`             | JSON string | Fires once after mount with the initial state            |
-| `models-available`  | JSON string | Fires once with the list of built-in example model names |
+| Event              | Payload     | Description                                              |
+| ------------------ | ----------- | -------------------------------------------------------- |
+| `state-update`     | JSON string | Fires on any change. Contains complete state             |
+| `bugs-code-update` | string      | Fires when the generated BUGS code changes               |
+| `stan-code-update` | string      | Fires when the generated Stan code changes               |
+| `ready`            | JSON string | Fires once after mount with the initial state            |
+| `models-available` | JSON string | Fires once with the list of built-in example model names |
 
 Both `bugs-code-update` and `stan-code-update` fire whenever the model changes, regardless of which language the user has visible in the code preview panel. Host applications that need one specific language should subscribe to the matching event.
 

--- a/DoodleBUGS/src/DoodleWidget.vue
+++ b/DoodleBUGS/src/DoodleWidget.vue
@@ -64,7 +64,8 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: 'state-update', payload: string): void
-  (e: 'code-update', payload: string): void
+  (e: 'bugs-code-update', payload: string): void
+  (e: 'stan-code-update', payload: string): void
   (e: 'ready', payload: string): void
   (e: 'models-available', payload: string): void
 }>()
@@ -281,7 +282,7 @@ const controlsStyle = computed(() => {
 
 const { elements, selectedElement, updateElement, deleteElement } = useGraphElements()
 const { parsedGraphData } = storeToRefs(dataStore)
-const { generatedCode } = useBugsCodeGenerator(elements)
+const { generatedCode: generatedBugsCode } = useBugsCodeGenerator(elements)
 const { generatedStanCode } = useStanCodeGenerator(elements)
 const { validateGraph, validationErrors } = useGraphValidator(elements, parsedGraphData)
 const { standaloneScript, samplerSettings } = storeToRefs(scriptStore)
@@ -292,7 +293,7 @@ const { loadUIState, saveUIState, saveLastGraphId, loadLastGraphId } = usePersis
 
 const actions = useEditorActions(
   elements,
-  generatedCode,
+  generatedBugsCode,
   persistencePrefix.value,
   generatedStanCode
 )
@@ -356,7 +357,7 @@ const {
   smartFit,
 } = actions
 
-const { emitReady } = useWidgetEmitter(emit, generatedCode)
+const { emitReady } = useWidgetEmitter(emit, generatedBugsCode, generatedStanCode)
 
 const codePanelLanguage = ref<CodeLanguage>('bugs')
 const codePanelTitle = computed(() =>
@@ -793,7 +794,7 @@ onUnmounted(() => {
 })
 
 watch(
-  [generatedCode, parsedGraphData, samplerSettings],
+  [generatedBugsCode, parsedGraphData, samplerSettings],
   () => {
     if (
       standaloneScript.value ||

--- a/DoodleBUGS/src/composables/useWidgetEmitter.ts
+++ b/DoodleBUGS/src/composables/useWidgetEmitter.ts
@@ -7,13 +7,15 @@ import { useDataStore } from '../stores/dataStore'
 
 export interface WidgetEmitFn {
   (e: 'state-update', payload: string): void
-  (e: 'code-update', payload: string): void
+  (e: 'bugs-code-update', payload: string): void
+  (e: 'stan-code-update', payload: string): void
   (e: 'ready', payload: string): void
 }
 
 export function useWidgetEmitter(
   emit: WidgetEmitFn,
-  generatedCode: Ref<string>,
+  generatedBugsCode: Ref<string>,
+  generatedStanCode: Ref<string>,
   options: { debounceMs?: number } = {}
 ) {
   const projectStore = useProjectStore()
@@ -66,9 +68,15 @@ export function useWidgetEmitter(
 
   watch([() => projectStore.stateVersion, () => graphStore.stateVersion], emitStateDebounced)
 
-  watch(generatedCode, (code) => {
+  watch(generatedBugsCode, (code: string) => {
     if (isReady.value) {
-      emit('code-update', code)
+      emit('bugs-code-update', code)
+    }
+  })
+
+  watch(generatedStanCode, (code: string) => {
+    if (isReady.value) {
+      emit('stan-code-update', code)
     }
   })
 
@@ -84,7 +92,8 @@ export function useWidgetEmitter(
 
     nextTick(() => {
       emit('state-update', json)
-      emit('code-update', generatedCode.value)
+      emit('bugs-code-update', generatedBugsCode.value)
+      emit('stan-code-update', generatedStanCode.value)
       emit('ready', json)
     })
   }


### PR DESCRIPTION
Replaces the single `code-update` event with two typed events: `bugs-code-update` and `stan-code-update`. Both fire whenever the model changes, independent of which language the user has visible in the code preview panel, so host applications that need one specific language no longer have to rely on the user picking it in the UI.

`useWidgetEmitter` now takes two refs (`generatedBugsCode`, `generatedStanCode`) and emits the two new events. `DoodleWidget.vue` updates its `defineEmits` and passes both refs into the emitter. The widget events table in `README.md` is updated to document all emitted events.

The previous `code-update` event is removed.