### PR TITLE
1. Variable type enum setup

### DIFF
--- a/JuliaBUGS/src/model/Model.jl
+++ b/JuliaBUGS/src/model/Model.jl
@@ -27,10 +27,10 @@ include("to_distribution.jl")
 # Public user-facing API
 export parameters, variables, initialize!, getparams, settrans, to_distribution
 export set_evaluation_mode, set_observed_values!
-export mcmc_parameters, postprocess_variables
+export model_parameters, generated_quantities, variable_type
 
 # Variable classification
-export VariableType, Deterministic, Observation, ModelParameter, GeneratedQuantity
+export VariableType, Observation, ModelParameter, TransformedParameter, GeneratedQuantity
 
 # Evaluation mode types
 export UseGraph, UseGeneratedLogDensityFunction, UseAutoMarginalization

--- a/JuliaBUGS/src/model/Model.jl
+++ b/JuliaBUGS/src/model/Model.jl
@@ -27,6 +27,7 @@ include("to_distribution.jl")
 # Public user-facing API
 export parameters, variables, initialize!, getparams, settrans, to_distribution
 export set_evaluation_mode, set_observed_values!
+export mcmc_parameters, postprocess_variables
 
 # Variable classification
 export VariableType, Deterministic, Observation, ModelParameter, GeneratedQuantity

--- a/JuliaBUGS/src/model/Model.jl
+++ b/JuliaBUGS/src/model/Model.jl
@@ -9,7 +9,7 @@ using Bijectors
 using Distributions
 using Graphs
 using LinearAlgebra
-using JuliaBUGS: JuliaBUGS, BUGSGraph
+using JuliaBUGS: JuliaBUGS, BUGSGraph, find_generated_quantities_variables
 using JuliaBUGS.BUGSPrimitives
 using LogExpFunctions
 using MetaGraphsNext
@@ -27,6 +27,9 @@ include("to_distribution.jl")
 # Public user-facing API
 export parameters, variables, initialize!, getparams, settrans, to_distribution
 export set_evaluation_mode, set_observed_values!
+
+# Variable classification
+export VariableType, Deterministic, Observation, ModelParameter, GeneratedQuantity
 
 # Evaluation mode types
 export UseGraph, UseGeneratedLogDensityFunction, UseAutoMarginalization

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -29,6 +29,18 @@ struct MarginalizationCache{V<:VarName}
 end
 
 """
+    VariableType
+
+Classification of each node in the model graph.
+
+- `Deterministic`: a logical node (defined with `=`)
+- `Observation`: a stochastic node with observed data
+- `ModelParameter`: a stochastic node that influences observations (sampled by MCMC)
+- `GeneratedQuantity`: a stochastic node with no observed descendants (can be forward-sampled post-inference)
+"""
+@enum VariableType Deterministic Observation ModelParameter GeneratedQuantity
+
+"""
     GraphEvaluationData{TNF,TV}
 
 Caches node information from the model graph to optimize evaluation performance.
@@ -37,6 +49,7 @@ Stores pre-computed values to avoid repeated lookups from the MetaGraph during m
 # Fields
 - `sorted_nodes::Vector{<:VarName}`: Variables in topological order for evaluation
 - `sorted_parameters::Vector{<:VarName}`: Parameters (unobserved stochastic variables) in sorted order consistent with sorted_nodes
+- `variable_types::Vector{VariableType}`: Classification of each node
 - `is_stochastic_vals::Vector{Bool}`: Whether each node represents a stochastic variable
 - `is_observed_vals::Vector{Bool}`: Whether each node is observed (has data)
 - `node_function_vals::TNF`: Functions that define each node's computation
@@ -45,6 +58,7 @@ Stores pre-computed values to avoid repeated lookups from the MetaGraph during m
 struct GraphEvaluationData{TNF,TV}
     sorted_nodes::Vector{<:VarName}
     sorted_parameters::Vector{<:VarName}
+    variable_types::Vector{VariableType}
     is_stochastic_vals::Vector{Bool}
     is_observed_vals::Vector{Bool}
     node_function_vals::TNF
@@ -69,6 +83,9 @@ function GraphEvaluationData(
     node_function_vals = Array{Any}(undef, length(sorted_nodes))
     loop_vars_vals = Array{Any}(undef, length(sorted_nodes))
     sorted_parameters = VarName[]
+    variable_types = Vector{VariableType}(undef, length(sorted_nodes))
+
+    gq_vars = find_generated_quantities_variables(g)
 
     for (i, vn) in enumerate(sorted_nodes)
         (; is_stochastic, is_observed, node_function, loop_vars) = g[vn]
@@ -76,6 +93,17 @@ function GraphEvaluationData(
         is_observed_vals[i] = is_observed
         node_function_vals[i] = node_function
         loop_vars_vals[i] = loop_vars
+
+        # Classify each node
+        variable_types[i] = if !is_stochastic
+            Deterministic
+        elseif is_observed
+            Observation
+        elseif vn in gq_vars
+            GeneratedQuantity
+        else
+            ModelParameter
+        end
 
         # If it's a stochastic variable and not observed, it's a parameter
         # If active_parameters is specified, only include those that are in the list
@@ -89,6 +117,7 @@ function GraphEvaluationData(
     return GraphEvaluationData{typeof(node_function_vals),typeof(loop_vars_vals)}(
         sorted_nodes,
         sorted_parameters,
+        variable_types,
         is_stochastic_vals,
         is_observed_vals,
         map(identity, node_function_vals),

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -49,6 +49,8 @@ Stores pre-computed values to avoid repeated lookups from the MetaGraph during m
 # Fields
 - `sorted_nodes::Vector{<:VarName}`: Variables in topological order for evaluation
 - `sorted_parameters::Vector{<:VarName}`: Parameters (unobserved stochastic variables) in sorted order consistent with sorted_nodes
+- `mcmc_parameters::Vector{<:VarName}`: Unobserved stochastic variables intended for direct MCMC updates
+- `postprocess_stochastic::Vector{<:VarName}`: Unobserved stochastic variables tracked for post-inference computation
 - `variable_types::Vector{VariableType}`: Classification of each node
 - `is_stochastic_vals::Vector{Bool}`: Whether each node represents a stochastic variable
 - `is_observed_vals::Vector{Bool}`: Whether each node is observed (has data)
@@ -58,6 +60,8 @@ Stores pre-computed values to avoid repeated lookups from the MetaGraph during m
 struct GraphEvaluationData{TNF,TV}
     sorted_nodes::Vector{<:VarName}
     sorted_parameters::Vector{<:VarName}
+    mcmc_parameters::Vector{<:VarName}
+    postprocess_stochastic::Vector{<:VarName}
     variable_types::Vector{VariableType}
     is_stochastic_vals::Vector{Bool}
     is_observed_vals::Vector{Bool}
@@ -83,6 +87,8 @@ function GraphEvaluationData(
     node_function_vals = Array{Any}(undef, length(sorted_nodes))
     loop_vars_vals = Array{Any}(undef, length(sorted_nodes))
     sorted_parameters = VarName[]
+    mcmc_parameters = VarName[]
+    postprocess_stochastic = VarName[]
     variable_types = Vector{VariableType}(undef, length(sorted_nodes))
 
     gq_vars = find_generated_quantities_variables(g)
@@ -110,6 +116,11 @@ function GraphEvaluationData(
         if is_stochastic && !is_observed
             if active_parameters === nothing || vn in active_parameters
                 push!(sorted_parameters, vn)
+                if variable_types[i] == GeneratedQuantity
+                    push!(postprocess_stochastic, vn)
+                else
+                    push!(mcmc_parameters, vn)
+                end
             end
         end
     end
@@ -117,6 +128,8 @@ function GraphEvaluationData(
     return GraphEvaluationData{typeof(node_function_vals),typeof(loop_vars_vals)}(
         sorted_nodes,
         sorted_parameters,
+        mcmc_parameters,
+        postprocess_stochastic,
         variable_types,
         is_stochastic_vals,
         is_observed_vals,
@@ -360,6 +373,20 @@ end
 Return a vector of `VarName` containing the names of the model parameters (unobserved stochastic variables).
 """
 parameters(model::BUGSModel) = model.graph_evaluation_data.sorted_parameters
+
+"""
+    mcmc_parameters(model::BUGSModel)
+
+Return a vector of `VarName` containing the stochastic variables that should be sampled directly by MCMC.
+"""
+mcmc_parameters(model::BUGSModel) = model.graph_evaluation_data.mcmc_parameters
+
+"""
+    postprocess_variables(model::BUGSModel)
+
+Return a vector of `VarName` containing unobserved stochastic variables that are tracked for post-processing rather than direct MCMC updates.
+"""
+postprocess_variables(model::BUGSModel) = model.graph_evaluation_data.postprocess_stochastic
 
 """
     variables(model::BUGSModel)

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -40,6 +40,23 @@ Classification of each node in the model graph.
 """
 @enum VariableType Deterministic Observation ModelParameter GeneratedQuantity
 
+@inline function _classify_variable_type(
+    vn::VarName, is_stochastic::Bool, is_observed::Bool, gq_vars::Set{<:VarName}
+)
+    return if !is_stochastic
+        Deterministic
+    elseif is_observed
+        Observation
+    elseif vn in gq_vars
+        # Stochastic node with no observed descendants (forward-sampled after inference).
+        GeneratedQuantity
+    else
+        # Includes latent variables such as missing-data interpolation that still
+        # influence observed likelihood terms and must remain in MCMC.
+        ModelParameter
+    end
+end
+
 """
     GraphEvaluationData{TNF,TV}
 
@@ -101,15 +118,7 @@ function GraphEvaluationData(
         loop_vars_vals[i] = loop_vars
 
         # Classify each node
-        variable_types[i] = if !is_stochastic
-            Deterministic
-        elseif is_observed
-            Observation
-        elseif vn in gq_vars
-            GeneratedQuantity
-        else
-            ModelParameter
-        end
+        variable_types[i] = _classify_variable_type(vn, is_stochastic, is_observed, gq_vars)
 
         # If it's a stochastic variable and not observed, it's a parameter
         # If active_parameters is specified, only include those that are in the list

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -33,27 +33,27 @@ end
 
 Classification of each node in the model graph.
 
-- `Deterministic`: a logical node (defined with `=`)
 - `Observation`: a stochastic node with observed data
 - `ModelParameter`: a stochastic node that influences observations (sampled by MCMC)
-- `GeneratedQuantity`: a stochastic node with no observed descendants (can be forward-sampled post-inference)
+- `TransformedParameter`: a deterministic node that needs to be computed during each iteration of sampling
+- `GeneratedQuantity`: a stochastic or deterministic node with no observed descendants (computed after getting samples)
 """
-@enum VariableType Deterministic Observation ModelParameter GeneratedQuantity
+@enum VariableType Observation ModelParameter TransformedParameter GeneratedQuantity
 
 @inline function _classify_variable_type(
     vn::VarName, is_stochastic::Bool, is_observed::Bool, gq_vars::Set{<:VarName}
 )
-    return if !is_stochastic
-        Deterministic
-    elseif is_observed
+    return if is_stochastic && is_observed
         Observation
     elseif vn in gq_vars
-        # Stochastic node with no observed descendants (forward-sampled after inference).
+        # No observed descendants
         GeneratedQuantity
-    else
-        # Includes latent variables such as missing-data interpolation that still
-        # influence observed likelihood terms and must remain in MCMC.
+    elseif is_stochastic
+        # Stochastic node that influences observed likelihood terms.
         ModelParameter
+    else
+        # Deterministic node needed during each sampling iteration.
+        TransformedParameter
     end
 end
 
@@ -66,8 +66,8 @@ Stores pre-computed values to avoid repeated lookups from the MetaGraph during m
 # Fields
 - `sorted_nodes::Vector{<:VarName}`: Variables in topological order for evaluation
 - `sorted_parameters::Vector{<:VarName}`: Parameters (unobserved stochastic variables) in sorted order consistent with sorted_nodes
-- `mcmc_parameters::Vector{<:VarName}`: Unobserved stochastic variables intended for direct MCMC updates
-- `postprocess_stochastic::Vector{<:VarName}`: Unobserved stochastic variables tracked for post-inference computation
+- `model_parameters::Vector{<:VarName}`: Unobserved stochastic variables that influence observations
+- `generated_quantities::Vector{<:VarName}`: Variables (stochastic or deterministic) with no observed descendants
 - `variable_types::Vector{VariableType}`: Classification of each node
 - `is_stochastic_vals::Vector{Bool}`: Whether each node represents a stochastic variable
 - `is_observed_vals::Vector{Bool}`: Whether each node is observed (has data)
@@ -77,8 +77,8 @@ Stores pre-computed values to avoid repeated lookups from the MetaGraph during m
 struct GraphEvaluationData{TNF,TV}
     sorted_nodes::Vector{<:VarName}
     sorted_parameters::Vector{<:VarName}
-    mcmc_parameters::Vector{<:VarName}
-    postprocess_stochastic::Vector{<:VarName}
+    model_parameters::Vector{<:VarName}
+    generated_quantities::Vector{<:VarName}
     variable_types::Vector{VariableType}
     is_stochastic_vals::Vector{Bool}
     is_observed_vals::Vector{Bool}
@@ -104,8 +104,8 @@ function GraphEvaluationData(
     node_function_vals = Array{Any}(undef, length(sorted_nodes))
     loop_vars_vals = Array{Any}(undef, length(sorted_nodes))
     sorted_parameters = VarName[]
-    mcmc_parameters = VarName[]
-    postprocess_stochastic = VarName[]
+    model_parameters = VarName[]
+    generated_quantities = VarName[]
     variable_types = Vector{VariableType}(undef, length(sorted_nodes))
 
     gq_vars = find_generated_quantities_variables(g)
@@ -120,16 +120,18 @@ function GraphEvaluationData(
         # Classify each node
         variable_types[i] = _classify_variable_type(vn, is_stochastic, is_observed, gq_vars)
 
-        # If it's a stochastic variable and not observed, it's a parameter
-        # If active_parameters is specified, only include those that are in the list
-        if is_stochastic && !is_observed
+        if variable_types[i] == GeneratedQuantity
+            # Both stochastic and deterministic nodes go here
+            push!(generated_quantities, vn)
+            if is_stochastic && !is_observed
+                if active_parameters === nothing || vn in active_parameters
+                    push!(sorted_parameters, vn)
+                end
+            end
+        elseif is_stochastic && !is_observed
             if active_parameters === nothing || vn in active_parameters
                 push!(sorted_parameters, vn)
-                if variable_types[i] == GeneratedQuantity
-                    push!(postprocess_stochastic, vn)
-                else
-                    push!(mcmc_parameters, vn)
-                end
+                push!(model_parameters, vn)
             end
         end
     end
@@ -137,8 +139,8 @@ function GraphEvaluationData(
     return GraphEvaluationData{typeof(node_function_vals),typeof(loop_vars_vals)}(
         sorted_nodes,
         sorted_parameters,
-        mcmc_parameters,
-        postprocess_stochastic,
+        model_parameters,
+        generated_quantities,
         variable_types,
         is_stochastic_vals,
         is_observed_vals,
@@ -384,18 +386,31 @@ Return a vector of `VarName` containing the names of the model parameters (unobs
 parameters(model::BUGSModel) = model.graph_evaluation_data.sorted_parameters
 
 """
-    mcmc_parameters(model::BUGSModel)
+    model_parameters(model::BUGSModel)
 
-Return a vector of `VarName` containing the stochastic variables that should be sampled directly by MCMC.
+Return a vector of `VarName` containing the stochastic variables that influence observations
+and should be sampled directly.
 """
-mcmc_parameters(model::BUGSModel) = model.graph_evaluation_data.mcmc_parameters
+model_parameters(model::BUGSModel) = model.graph_evaluation_data.model_parameters
 
 """
-    postprocess_variables(model::BUGSModel)
+    generated_quantities(model::BUGSModel)
 
-Return a vector of `VarName` containing unobserved stochastic variables that are tracked for post-processing rather than direct MCMC updates.
+Return a vector of `VarName` containing variables with no observed descendants. These can be computed after getting samples.
 """
-postprocess_variables(model::BUGSModel) = model.graph_evaluation_data.postprocess_stochastic
+generated_quantities(model::BUGSModel) = model.graph_evaluation_data.generated_quantities
+
+"""
+    variable_type(model::BUGSModel, vn::VarName)
+
+Return the `VariableType` classification for variable `vn` in the model.
+"""
+function variable_type(model::BUGSModel, vn::VarName)
+    gd = model.graph_evaluation_data
+    idx = findfirst(==(vn), gd.sorted_nodes)
+    idx === nothing && throw(ArgumentError("Variable \"$(vn)\" does not exist in the model"))
+    return gd.variable_types[idx]
+end
 
 """
     variables(model::BUGSModel)

--- a/JuliaBUGS/test/ad_compatibility.jl
+++ b/JuliaBUGS/test/ad_compatibility.jl
@@ -116,9 +116,10 @@
         x = JuliaBUGS.getparams(model)
 
         @testset "AutoReverseDiff - should warn and switch to UseGraph" begin
-            grad_model = @test_warn "does not support mutation" JuliaBUGS.BUGSModelWithGradient(
-                model, AutoReverseDiff()
-            )
+            # Note: The warning uses maxlog=1, so it may be suppressed if another
+            # test in the suite triggered it first. We only assert the behavioral
+            # invariant (mode switches to UseGraph).
+            grad_model = JuliaBUGS.BUGSModelWithGradient(model, AutoReverseDiff())
             @test grad_model.base_model.evaluation_mode isa JuliaBUGS.UseGraph
 
             # Should still work after switching

--- a/JuliaBUGS/test/model/bugsmodel.jl
+++ b/JuliaBUGS/test/model/bugsmodel.jl
@@ -8,7 +8,12 @@ using JuliaBUGS.Model:
     settrans,
     set_evaluation_mode,
     UseGeneratedLogDensityFunction,
-    UseGraph
+    UseGraph,
+    VariableType,
+    Deterministic,
+    Observation,
+    ModelParameter,
+    GeneratedQuantity
 
 @testset "Compile Vol.1 BUGS Examples" begin
     for model_name in keys(JuliaBUGS.BUGSExamples.VOLUME_1)
@@ -84,6 +89,44 @@ end
             condition(model, Dict(@varname(x) => [1.0, 2.0, 3.0]))
         )
         @test length(parameters(model_subsume)) == 2  # Only mu and sigma remain
+    end
+
+    @testset "VariableType classification" begin
+        # Model with deterministic, observation, and model parameters
+        model_def = @bugs begin
+            mu ~ Normal(0, 10)
+            sigma ~ Gamma(1, 1)
+            for i in 1:3
+                x[i] ~ Normal(mu, sigma)
+            end
+            mean_x = mean(x[:])
+            y ~ Normal(mean_x, 1)
+        end
+
+        model = compile(model_def, (; y=2.5))
+        gd = model.graph_evaluation_data
+        type_of = Dict(gd.sorted_nodes .=> gd.variable_types)
+
+        @test type_of[@varname(mu)] == ModelParameter
+        @test type_of[@varname(sigma)] == ModelParameter
+        @test type_of[@varname(x[1])] == ModelParameter
+        @test type_of[@varname(mean_x)] == Deterministic
+        @test type_of[@varname(y)] == Observation
+
+        # Model with a generated quantity
+        model_def_gq = @bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            z ~ Normal(mu, 1)  # no observation depends on z
+        end
+
+        model_gq = compile(model_def_gq, (; y=1.0))
+        gd_gq = model_gq.graph_evaluation_data
+        type_of_gq = Dict(gd_gq.sorted_nodes .=> gd_gq.variable_types)
+
+        @test type_of_gq[@varname(mu)] == ModelParameter
+        @test type_of_gq[@varname(y)] == Observation
+        @test type_of_gq[@varname(z)] == GeneratedQuantity
     end
 
     @testset "initialize!" begin

--- a/JuliaBUGS/test/model/bugsmodel.jl
+++ b/JuliaBUGS/test/model/bugsmodel.jl
@@ -133,6 +133,34 @@ end
         @test @varname(mu) in mcmc_parameters(model_gq)
         @test @varname(z) ∉ mcmc_parameters(model_gq)
         @test @varname(z) in postprocess_variables(model_gq)
+
+        # Missing-data interpolation that influences observed likelihood
+        # should remain a model parameter (sampled by MCMC).
+        model_def_missing = @bugs begin
+            x ~ Normal(0, 1)
+            y ~ Normal(x, 1)
+        end
+        model_missing = compile(model_def_missing, (; y=missing))
+        gd_missing = model_missing.graph_evaluation_data
+        type_of_missing = Dict(gd_missing.sorted_nodes .=> gd_missing.variable_types)
+
+        @test type_of_missing[@varname(y)] == ModelParameter
+        @test @varname(y) in mcmc_parameters(model_missing)
+        @test @varname(y) ∉ postprocess_variables(model_missing)
+
+        # Unobserved stochastic node with no observed descendants should be postprocessed.
+        model_def_post = @bugs begin
+            θ ~ Normal(0, 1)
+            y ~ Normal(θ, 1)
+            z ~ Normal(θ, 1)
+        end
+        model_post = compile(model_def_post, (; y=1.0))
+        gd_post = model_post.graph_evaluation_data
+        type_of_post = Dict(gd_post.sorted_nodes .=> gd_post.variable_types)
+
+        @test type_of_post[@varname(z)] == GeneratedQuantity
+        @test @varname(z) ∉ mcmc_parameters(model_post)
+        @test @varname(z) in postprocess_variables(model_post)
     end
 
     @testset "initialize!" begin

--- a/JuliaBUGS/test/model/bugsmodel.jl
+++ b/JuliaBUGS/test/model/bugsmodel.jl
@@ -4,6 +4,8 @@ using JuliaBUGS.Model:
     decondition,
     parameters,
     variables,
+    mcmc_parameters,
+    postprocess_variables,
     getparams,
     settrans,
     set_evaluation_mode,
@@ -127,6 +129,10 @@ end
         @test type_of_gq[@varname(mu)] == ModelParameter
         @test type_of_gq[@varname(y)] == Observation
         @test type_of_gq[@varname(z)] == GeneratedQuantity
+
+        @test @varname(mu) in mcmc_parameters(model_gq)
+        @test @varname(z) ∉ mcmc_parameters(model_gq)
+        @test @varname(z) in postprocess_variables(model_gq)
     end
 
     @testset "initialize!" begin

--- a/JuliaBUGS/test/model/bugsmodel.jl
+++ b/JuliaBUGS/test/model/bugsmodel.jl
@@ -139,8 +139,9 @@ end
         model_def_missing = @bugs begin
             x ~ Normal(0, 1)
             y ~ Normal(x, 1)
+            z ~ Normal(y, 1)
         end
-        model_missing = compile(model_def_missing, (; y=missing))
+        model_missing = compile(model_def_missing, (; y=missing, z=1.0))
         gd_missing = model_missing.graph_evaluation_data
         type_of_missing = Dict(gd_missing.sorted_nodes .=> gd_missing.variable_types)
 

--- a/JuliaBUGS/test/model/bugsmodel.jl
+++ b/JuliaBUGS/test/model/bugsmodel.jl
@@ -4,17 +4,18 @@ using JuliaBUGS.Model:
     decondition,
     parameters,
     variables,
-    mcmc_parameters,
-    postprocess_variables,
+    model_parameters,
+    generated_quantities,
+    variable_type,
     getparams,
     settrans,
     set_evaluation_mode,
     UseGeneratedLogDensityFunction,
     UseGraph,
     VariableType,
-    Deterministic,
     Observation,
     ModelParameter,
+    TransformedParameter,
     GeneratedQuantity
 
 @testset "Compile Vol.1 BUGS Examples" begin
@@ -94,7 +95,7 @@ end
     end
 
     @testset "VariableType classification" begin
-        # Model with deterministic, observation, and model parameters
+        # Model with all four variable types
         model_def = @bugs begin
             mu ~ Normal(0, 10)
             sigma ~ Gamma(1, 1)
@@ -106,16 +107,18 @@ end
         end
 
         model = compile(model_def, (; y=2.5))
-        gd = model.graph_evaluation_data
-        type_of = Dict(gd.sorted_nodes .=> gd.variable_types)
 
-        @test type_of[@varname(mu)] == ModelParameter
-        @test type_of[@varname(sigma)] == ModelParameter
-        @test type_of[@varname(x[1])] == ModelParameter
-        @test type_of[@varname(mean_x)] == Deterministic
-        @test type_of[@varname(y)] == Observation
+        # Test variable_type accessor
+        @test variable_type(model, @varname(mu)) == ModelParameter
+        @test variable_type(model, @varname(sigma)) == ModelParameter
+        @test variable_type(model, @varname(x[1])) == ModelParameter
+        @test variable_type(model, @varname(mean_x)) == TransformedParameter
+        @test variable_type(model, @varname(y)) == Observation
 
-        # Model with a generated quantity
+        # variable_type should error on nonexistent variables
+        @test_throws ArgumentError variable_type(model, @varname(nonexistent))
+
+        # Model with a stochastic generated quantity
         model_def_gq = @bugs begin
             mu ~ Normal(0, 1)
             y ~ Normal(mu, 1)
@@ -123,45 +126,83 @@ end
         end
 
         model_gq = compile(model_def_gq, (; y=1.0))
-        gd_gq = model_gq.graph_evaluation_data
-        type_of_gq = Dict(gd_gq.sorted_nodes .=> gd_gq.variable_types)
 
-        @test type_of_gq[@varname(mu)] == ModelParameter
-        @test type_of_gq[@varname(y)] == Observation
-        @test type_of_gq[@varname(z)] == GeneratedQuantity
+        @test variable_type(model_gq, @varname(mu)) == ModelParameter
+        @test variable_type(model_gq, @varname(y)) == Observation
+        @test variable_type(model_gq, @varname(z)) == GeneratedQuantity
 
-        @test @varname(mu) in mcmc_parameters(model_gq)
-        @test @varname(z) ∉ mcmc_parameters(model_gq)
-        @test @varname(z) in postprocess_variables(model_gq)
+        @test @varname(mu) in model_parameters(model_gq)
+        @test @varname(z) ∉ model_parameters(model_gq)
+        @test @varname(z) in generated_quantities(model_gq)
 
         # Missing-data interpolation that influences observed likelihood
-        # should remain a model parameter (sampled by MCMC).
+        # should remain a model parameter.
         model_def_missing = @bugs begin
             x ~ Normal(0, 1)
             y ~ Normal(x, 1)
             z ~ Normal(y, 1)
         end
         model_missing = compile(model_def_missing, (; y=missing, z=1.0))
-        gd_missing = model_missing.graph_evaluation_data
-        type_of_missing = Dict(gd_missing.sorted_nodes .=> gd_missing.variable_types)
 
-        @test type_of_missing[@varname(y)] == ModelParameter
-        @test @varname(y) in mcmc_parameters(model_missing)
-        @test @varname(y) ∉ postprocess_variables(model_missing)
+        @test variable_type(model_missing, @varname(y)) == ModelParameter
+        @test @varname(y) in model_parameters(model_missing)
+        @test @varname(y) ∉ generated_quantities(model_missing)
 
-        # Unobserved stochastic node with no observed descendants should be postprocessed.
+        # Unobserved stochastic node with no observed descendants
         model_def_post = @bugs begin
             θ ~ Normal(0, 1)
             y ~ Normal(θ, 1)
             z ~ Normal(θ, 1)
         end
         model_post = compile(model_def_post, (; y=1.0))
-        gd_post = model_post.graph_evaluation_data
-        type_of_post = Dict(gd_post.sorted_nodes .=> gd_post.variable_types)
 
-        @test type_of_post[@varname(z)] == GeneratedQuantity
-        @test @varname(z) ∉ mcmc_parameters(model_post)
-        @test @varname(z) in postprocess_variables(model_post)
+        @test variable_type(model_post, @varname(z)) == GeneratedQuantity
+        @test @varname(z) ∉ model_parameters(model_post)
+        @test @varname(z) in generated_quantities(model_post)
+
+        # Deterministic node with no observed descendants
+        model_def_det_gq = @bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            pred = mu + 1.0
+        end
+        model_det_gq = compile(model_def_det_gq, (; y=1.0))
+
+        @test variable_type(model_det_gq, @varname(pred)) == GeneratedQuantity
+        @test @varname(pred) in generated_quantities(model_det_gq)
+    end
+
+    @testset "Classification invariants" begin
+        model_def = @bugs begin
+            mu ~ Normal(0, 10)
+            sigma ~ Gamma(1, 1)
+            for i in 1:3
+                x[i] ~ Normal(mu, sigma)
+            end
+            mean_x = mean(x[:])
+            y ~ Normal(mean_x, 1)
+            z ~ Normal(mu, 1)
+            pred = mu + sigma
+        end
+
+        model = compile(model_def, (; y=2.5))
+        mp = model_parameters(model)
+        gq = generated_quantities(model)
+
+        # model_parameters and generated_quantities are disjoint
+        @test isempty(intersect(Set(mp), Set(gq)))
+
+        # Every unobserved stochastic node is in exactly one partition
+        for vn in parameters(model)
+            @test (vn in mp) ⊻ (vn in gq)
+        end
+
+        # Deterministic nodes with no observed descendants are in generated_quantities
+        @test @varname(pred) in gq
+
+        # TransformedParameters are in neither
+        @test @varname(mean_x) ∉ mp
+        @test @varname(mean_x) ∉ gq
     end
 
     @testset "initialize!" begin


### PR DESCRIPTION
#443 
1
- Added a `VariableType` enum - Deterministic, Observation, ModelParameter, GeneratedQuantity to classify each node in the model graph. 
- Splits stochastic parameters into `mcmc_parameters` and `postprocess_stochastic`