### PR TITLE
3. Forward sample generated quantities

### DIFF
--- a/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
@@ -6,6 +6,7 @@ using JuliaBUGS:
     BUGSModel,
     BUGSModelWithGradient,
     find_generated_quantities_variables,
+    postprocess_variables,
     evaluate!!,
     getparams
 using JuliaBUGS.Model: UseAutoMarginalization
@@ -144,21 +145,37 @@ function JuliaBUGS.gen_chains(
         gd.sorted_parameters
     end
 
-    # Find and order generated quantities
-    # Exclude parameters to avoid double counting forward-sampled variables
-    generated_vars = find_generated_quantities_variables(model.g)
+    # Find all generated quantities (both deterministic and stochastic) for chain columns.
+    # Use graph-based detection for the full list, then filter to topo order and exclude params.
+    all_gq_vars = find_generated_quantities_variables(model.g)
     param_set = Set(param_vars)
-    generated_vars = [v for v in gd.sorted_nodes if v in generated_vars && v ∉ param_set]
+    generated_vars = [v for v in gd.sorted_nodes if v in all_gq_vars && v ∉ param_set]
 
-    # Evaluate model for each sample to get parameter values and generated quantities
+    # Identify which GQs need forward-sampling (stochastic only).
+    # Deterministic GQs are already computed by evaluate!!.
+    stochastic_gq_set = Set(postprocess_variables(model))
+
+    # Evaluate model for each sample to get parameter values and forward-sample stochastic GQs
     param_vals = []
     generated_quantities = []
     for i in axes(samples)[1]
-        # Set parameters and evaluate the model
+        # Set MCMC parameters and evaluate the model (computes deterministic nodes + log-density)
         evaluation_env = first(evaluate!!(model, samples[i]))
 
+        # Forward-sample stochastic generated quantities: draw from their distributions
+        # using the freshly computed evaluation environment
+        for vn in generated_vars
+            if vn in stochastic_gq_set
+                idx = findfirst(==(vn), gd.sorted_nodes)
+                node_function = gd.node_function_vals[idx]
+                loop_vars = gd.loop_vars_vals[idx]
+                dist = node_function(evaluation_env, loop_vars)
+                value = rand(dist)
+                evaluation_env = JuliaBUGS.BangBang.setindex!!(evaluation_env, value, vn)
+            end
+        end
+
         # Get parameter values from the evaluation environment
-        # (they were just set by evaluate!!, so they match samples[i])
         push!(
             param_vals,
             [AbstractPPL.getvalue(evaluation_env, param_var) for param_var in param_vars],

--- a/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
@@ -162,16 +162,26 @@ function JuliaBUGS.gen_chains(
         # Set MCMC parameters and evaluate the model (computes deterministic nodes + log-density)
         evaluation_env = first(evaluate!!(model, samples[i]))
 
-        # Forward-sample stochastic generated quantities: draw from their distributions
-        # using the freshly computed evaluation environment
-        for vn in generated_vars
-            if vn in stochastic_gq_set
+        if !isnothing(model.postprocess_function)
+            # The postprocess function re-evaluates all deterministic nodes
+            # and forward-samples stochastic generated quantities in a single compiled pass.
+            evaluation_env = Base.invokelatest(model.postprocess_function, evaluation_env)
+        else
+            # forward-sample stochastic generated quantities, then re-evaluate deterministic GQs that may depend on them.
+            for vn in generated_vars
                 idx = findfirst(==(vn), gd.sorted_nodes)
+                is_stochastic = gd.is_stochastic_vals[idx]
                 node_function = gd.node_function_vals[idx]
                 loop_vars = gd.loop_vars_vals[idx]
-                dist = node_function(evaluation_env, loop_vars)
-                value = rand(dist)
-                evaluation_env = JuliaBUGS.BangBang.setindex!!(evaluation_env, value, vn)
+                if is_stochastic && vn in stochastic_gq_set
+                    dist = node_function(evaluation_env, loop_vars)
+                    value = rand(dist)
+                    evaluation_env = JuliaBUGS.BangBang.setindex!!(evaluation_env, value, vn)
+                elseif !is_stochastic
+                    # Recompute deterministic GQ nodes (may depend on freshly sampled GQs)
+                    value = node_function(evaluation_env, loop_vars)
+                    evaluation_env = JuliaBUGS.BangBang.setindex!!(evaluation_env, value, vn)
+                end
             end
         end
 

--- a/JuliaBUGS/src/model/abstractppl.jl
+++ b/JuliaBUGS/src/model/abstractppl.jl
@@ -564,6 +564,7 @@ function _create_modified_model(
         :graph_evaluation_data => new_graph_evaluation_data,
         :g => new_graph,
         :log_density_computation_function => nothing,  # Invalidate: graph changed
+        :postprocess_function => nothing,  # Invalidate: graph changed
         :marginalization_cache => nothing,  # Invalidate: graph changed
         :mutable_symbols => new_mutable_symbols,
         :evaluation_mode => UseGraph(),  # Reset to safe default

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -124,6 +124,8 @@ The `BUGSModel` object is used for inference and represents the output of compil
 - `graph_evaluation_data::GraphEvaluationData{TNF,TV}`: Pre-computed node values for evaluation.
 - `log_density_computation_function::F`: Generated log-density function (lazy, for
   `UseGeneratedLogDensityFunction` mode).
+- `postprocess_function::PF`: Generated function for forward-sampling GQs and recomputing
+  deterministic dependencies (lazy, compiled alongside log-density function).
 - `marginalization_cache::MC`: Cache for auto-marginalization (lazy, for
   `UseAutoMarginalization` mode). Invalidated when graph structure changes.
 - `mutable_symbols::Set{Symbol}`: Symbols that may be mutated during evaluation.
@@ -137,6 +139,7 @@ struct BUGSModel{
     TV,
     data_T,
     F<:Union{Function,Nothing},
+    PF<:Union{Function,Nothing},
     MC<:Union{MarginalizationCache,Nothing},
 } <: AbstractBUGSModel
     model_def::Expr
@@ -157,6 +160,7 @@ struct BUGSModel{
     graph_evaluation_data::GraphEvaluationData{TNF,TV}
 
     log_density_computation_function::F
+    postprocess_function::PF
 
     marginalization_cache::MC
 
@@ -179,6 +183,7 @@ function BUGSModel(
     base_model::Union{<:AbstractBUGSModel,Nothing}=model.base_model,
     evaluation_mode::EvaluationMode=model.evaluation_mode,
     log_density_computation_function::Union{Function,Nothing}=model.log_density_computation_function,
+    postprocess_function::Union{Function,Nothing}=model.postprocess_function,
     marginalization_cache::Union{MarginalizationCache,Nothing}=model.marginalization_cache,
     mutable_symbols::Set{Symbol}=model.mutable_symbols,
     model_def::Expr=model.model_def,
@@ -198,6 +203,7 @@ function BUGSModel(
         transformed_var_lengths,
         graph_evaluation_data,
         log_density_computation_function,
+        postprocess_function,
         marginalization_cache,
         mutable_symbols,
         base_model,
@@ -317,6 +323,7 @@ function BUGSModel(
         transformed_var_lengths,
         graph_evaluation_data,
         nothing,  # log_density_computation_function - generated on-demand
+        nothing,  # postprocess_function - generated on-demand
         nothing,  # marginalization_cache - generated on-demand
         mutable_symbols,
         nothing,
@@ -586,6 +593,14 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                     JuliaBUGS, log_density_computation_expr
                 )
 
+                # Compile postprocess function for forward-sampling GQs
+                postprocess_expr = JuliaBUGS._gen_postprocess_function_expr(
+                    lowered_model_def,
+                    model.evaluation_env,
+                    gensym(:__postprocess_gq__),
+                )
+                postprocess_function = Core.eval(JuliaBUGS, postprocess_expr)
+
                 # Update sorted_nodes based on reconstructed model to ensure parameter ordering
                 # consistency between UseGraph and UseGeneratedLogDensityFunction modes
                 pass = JuliaBUGS.CollectSortedNodes(model.evaluation_env)
@@ -604,6 +619,11 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                     model,
                     :log_density_computation_function,
                     log_density_computation_function,
+                )
+                model = BangBang.setproperty!!(
+                    model,
+                    :postprocess_function,
+                    postprocess_function,
                 )
             end
         end

--- a/JuliaBUGS/src/source_gen.jl
+++ b/JuliaBUGS/src/source_gen.jl
@@ -336,7 +336,7 @@ function __check_for_reserved_names(model_def::Expr)
     bad_variable_names = filter(
         variable_name ->
             startswith(string(variable_name), "__") &&
-            endswith(string(variable_name), "__"),
+                endswith(string(variable_name), "__"),
         variable_names,
     )
     if !isempty(bad_variable_names)
@@ -553,9 +553,7 @@ function __gen_logp_density_function_body_exprs(stmts::Vector, evaluation_env, e
             elseif stmt.args[1] == :≂
                 push!(exprs, __gen_observe_exprs(stmt))
             elseif stmt.args[1] == :≃
-                # Generated quantities don't contribute to log-density.
-                # Skip them entirely to keep the log-density function deterministic.
-                nothing
+                push!(exprs, __gen_generated_quantity_exprs(stmt))
             else
                 push!(exprs, __gen_observe_exprs(stmt))
             end
@@ -638,6 +636,76 @@ function __gen_model_parameter_exprs(stmt)
         __logprior__ = Distributions.logpdf(__dist__, __value__) + __logjac__
         __logp__ = __logp__ + __logprior__
         $lhs = __value__
+    end
+end
+
+# Generates a compiled function that forward-samples stochastic generated quantities and recomputes deterministic dependencies.
+
+function _gen_postprocess_function_expr(
+    model_def, evaluation_env, function_name::Symbol=:__postprocess_gq__
+)
+    env_keys = keys(evaluation_env)
+    return MacroTools.@q function $function_name(__evaluation_env__)
+        (; $(env_keys...)) = __evaluation_env__
+        $(__gen_postprocess_body_exprs(model_def.args, evaluation_env)...)
+        return (; $(env_keys...))
+    end
+end
+
+function __gen_postprocess_body_exprs(stmts::Vector, evaluation_env, exprs=Expr[])
+    for stmt in stmts
+        if Meta.isexpr(stmt, :(=))
+            push!(exprs, __gen_deterministic_exprs(stmt))
+        elseif Meta.isexpr(stmt, :call)
+            if stmt.args[1] == :~
+                # MCMC parameters: values already in env from evaluate!!, skip.
+                nothing
+            elseif stmt.args[1] == :≂
+                # Observations: values already in env, skip.
+                nothing
+            elseif stmt.args[1] == :≃
+                push!(exprs, __gen_generated_quantity_exprs(stmt))
+            else
+                error("Unknown operator: $(stmt.args[1])")
+            end
+        elseif Meta.isexpr(stmt, :for)
+            new_body = __gen_postprocess_body_exprs(stmt.args[2].args, evaluation_env)
+            new_for = Expr(:for, stmt.args[1], Expr(:block, new_body...))
+            push!(exprs, new_for)
+        elseif Meta.isexpr(stmt, :if)
+            new_if = _handle_if_expr_postprocess(stmt, evaluation_env)
+            push!(exprs, new_if)
+        elseif Meta.isexpr(stmt, :block)
+            new_inner = __gen_postprocess_body_exprs(stmt.args, evaluation_env)
+            append!(exprs, new_inner)
+        else
+            error("Unsupported statement: $stmt")
+        end
+    end
+    return exprs
+end
+
+function _handle_if_expr_postprocess(stmt, evaluation_env)
+    cond_expr = stmt.args[1]
+    then_expr = stmt.args[2]
+    elseif_or_else_expr = length(stmt.args) == 3 ? stmt.args[3] : nothing
+
+    new_then_body = __gen_postprocess_body_exprs(then_expr.args, evaluation_env)
+    new_then_block = Expr(:block, new_then_body...)
+    new_else_block = _handle_else_expr_postprocess(elseif_or_else_expr, evaluation_env)
+    return Expr(:if, cond_expr, new_then_block, new_else_block)
+end
+
+function _handle_else_expr_postprocess(expr, evaluation_env)
+    if expr === nothing
+        return nothing
+    elseif Meta.isexpr(expr, :elseif)
+        return _handle_if_expr_postprocess(expr, evaluation_env)
+    elseif Meta.isexpr(expr, :block)
+        new_else_body = __gen_postprocess_body_exprs(expr.args, evaluation_env)
+        return Expr(:block, new_else_body...)
+    else
+        error("Unsupported else expression: $expr")
     end
 end
 

--- a/JuliaBUGS/src/source_gen.jl
+++ b/JuliaBUGS/src/source_gen.jl
@@ -550,6 +550,12 @@ function __gen_logp_density_function_body_exprs(stmts::Vector, evaluation_env, e
         elseif Meta.isexpr(stmt, :call)
             if stmt.args[1] == :~
                 push!(exprs, __gen_model_parameter_exprs(stmt).args...)
+            elseif stmt.args[1] == :≂
+                push!(exprs, __gen_observe_exprs(stmt))
+            elseif stmt.args[1] == :≃
+                # Generated quantities don't contribute to log-density.
+                # Skip them entirely to keep the log-density function deterministic.
+                nothing
             else
                 push!(exprs, __gen_observe_exprs(stmt))
             end


### PR DESCRIPTION
#443 
3

- Added `_gen_postprocess_function_expr` generated quantities stochastic nodes now get forward-sampled from their distributions and deterministic nodes get recomputed