### PR TITLE
4. Margenalized latents

### DIFF
--- a/JuliaBUGS/src/model/Model.jl
+++ b/JuliaBUGS/src/model/Model.jl
@@ -37,5 +37,6 @@ export BUGSModelWithGradient
 # Internal evaluation functions (exported for testing, not re-exported to users)
 export evaluate_with_rng!!, evaluate_with_env!!, evaluate_with_values!!
 export evaluate_with_marginalization_values!!
+export evaluate_and_sample_with_marginalization_values!!
 
 end # Model

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -566,6 +566,19 @@ function _marginalize_recursive(
         )
         (rest_prior, obs_logp + rest_lik)
 
+    elseif gd.variable_types[current_idx] == GeneratedQuantity
+        # Stochastic nodes not in param_offsets / param_lengths: skip them.
+        _marginalize_recursive(
+            model,
+            env,
+            rest_indices,
+            parameter_values,
+            param_offsets,
+            var_lengths,
+            memo,
+            minimal_keys,
+        )
+
     elseif mc.node_types[current_idx] == :discrete_finite
         # Discrete finite unobserved: marginalize by enumerating all values
         dist = node_function(env, loop_vars)
@@ -699,3 +712,105 @@ function evaluate_with_marginalization_values!!(
         tempered_logjoint=log_prior + temperature * log_likelihood,
     )
 end
+
+"""
+    evaluate_and_sample_with_marginalization_values!!(model, flattened_values)
+
+Reconstruct continuous parameters and ancestrally sample marginalized discrete
+finite variables from their conditional posterior.
+
+This is used in `gen_chains` under `UseAutoMarginalization` so that generated quantities
+which depend on marginalized discrete latents get correct values.
+"""
+function evaluate_and_sample_with_marginalization_values!!(
+    model::BUGSModel, flattened_values::AbstractVector
+)
+    mc = model.marginalization_cache
+    if isnothing(mc)
+        error(
+            "Auto marginalization cache missing. " *
+            "Call set_evaluation_mode(model, UseAutoMarginalization()) first.",
+        )
+    end
+
+    gd = model.graph_evaluation_data
+    T = eltype(flattened_values)
+
+    # Fresh memo cache for _marginalize_recursive calls
+    n_nodes = length(gd.sorted_nodes)
+    expected_entries = if mc.n_discrete_finite > 20
+        1_000_000
+    else
+        min((1 << mc.n_discrete_finite) * n_nodes, 1_000_000)
+    end
+    memo = Dict{Tuple{Int,Tuple},Tuple{T,T}}()
+    sizehint!(memo, expected_entries)
+
+    env = smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols)
+
+    for (pos, idx) in enumerate(mc.marginalization_order)
+        vn = gd.sorted_nodes[idx]
+        node_function = gd.node_function_vals[idx]
+        loop_vars = gd.loop_vars_vals[idx]
+
+        if !gd.is_stochastic_vals[idx]
+            value = node_function(env, loop_vars)
+            env = BangBang.setindex!!(env, value, vn)
+
+        elseif gd.is_observed_vals[idx]
+            continue
+
+        elseif gd.variable_types[idx] == GeneratedQuantity
+            continue
+
+        elseif mc.node_types[idx] == :discrete_finite
+            # Marginalized discrete latent: sample from conditional posterior.
+            # For each possible value, compute the full downstream joint via
+            # _marginalize_recursive, then normalize and draw.
+            dist = node_function(env, loop_vars)
+            possible_values = _enumerate_discrete_values(dist)
+            rest_indices = @view(mc.marginalization_order[(pos + 1):end])
+
+            log_joints = Vector{T}(undef, length(possible_values))
+            for (i, val) in enumerate(possible_values)
+                branch_env = BangBang.setindex!!(env, val, vn)
+                val_logp = logpdf(dist, val)
+                val_logp = isnan(val_logp) ? -Inf : val_logp
+
+                branch_prior, branch_lik = _marginalize_recursive(
+                    model,
+                    branch_env,
+                    rest_indices,
+                    flattened_values,
+                    mc.param_offsets,
+                    mc.param_lengths,
+                    memo,
+                    mc.minimal_cache_keys,
+                )
+                log_joints[i] = val_logp + branch_prior + branch_lik
+            end
+
+            # Sample from conditional posterior weights
+            probs = LogExpFunctions.softmax(log_joints)
+            sampled_val = possible_values[rand(Distributions.Categorical(probs))]
+            env = BangBang.setindex!!(env, sampled_val, vn)
+
+        else
+            dist = node_function(env, loop_vars)
+            bijector = Bijectors.bijector(dist)
+
+            len = mc.param_lengths[vn]
+            start_idx = mc.param_offsets[vn]
+            param_slice = view(flattened_values, start_idx:(start_idx + len - 1))
+
+            b_inv = Bijectors.inverse(bijector)
+            reconstructed = reconstruct(b_inv, dist, param_slice)
+            value, _ = Bijectors.with_logabsdet_jacobian(b_inv, reconstructed)
+
+            env = BangBang.setindex!!(env, value, vn)
+        end
+    end
+
+    return env
+end
+

--- a/JuliaBUGS/test/model/auto_marginalization_sampling.jl
+++ b/JuliaBUGS/test/model/auto_marginalization_sampling.jl
@@ -2,8 +2,7 @@ using JuliaBUGS: @bugs, compile, settrans, getparams, initialize!
 using JuliaBUGS.Model:
     set_evaluation_mode,
     UseAutoMarginalization,
-    parameters,
-    evaluate_with_marginalization_values!!
+    evaluate_and_sample_with_marginalization_values!!
 
 @testset "Auto-Marginalization Sampling (NUTS)" begin
     # 2-component GMM with fixed weights. Discrete z marginalized out.
@@ -93,4 +92,287 @@ using JuliaBUGS.Model:
     # Direct comparison to ground truth with absolute tolerance
     @test isapprox(mu1_hat, true_mu[1]; atol=0.20)
     @test isapprox(mu2_hat, true_mu[2]; atol=0.20)
+end
+
+@testset "Ancestral sampler continuous params reconstructed" begin
+    # Verify continuous parameters in the returned env match the input vector
+    mixture_def = @bugs begin
+        w[1] = 0.3
+        w[2] = 0.7
+        mu[1] ~ Normal(-2, 5)
+        mu[2] ~ Normal(2, 5)
+        sigma[1] ~ Exponential(1)
+        sigma[2] ~ Exponential(1)
+        for i in 1:N
+            z[i] ~ Categorical(w[1:2])
+            y[i] ~ Normal(mu[z[i]], sigma[z[i]])
+        end
+    end
+
+    data = (N=4, y=[-1.5, 2.3, -2.1, 1.8])
+    model = compile(mixture_def, data)
+    model = settrans(model, true)
+    model = set_evaluation_mode(model, UseAutoMarginalization())
+
+    test_params = [0.0, 0.0, 2.0, -2.0]
+
+    env = Base.invokelatest(
+        evaluate_and_sample_with_marginalization_values!!, model, test_params
+    )
+
+    @test isapprox(AbstractPPL.getvalue(env, @varname(sigma[1])), 1.0; atol=1e-10)
+    @test isapprox(AbstractPPL.getvalue(env, @varname(sigma[2])), 1.0; atol=1e-10)
+    @test isapprox(AbstractPPL.getvalue(env, @varname(mu[2])), 2.0; atol=1e-10)
+    @test isapprox(AbstractPPL.getvalue(env, @varname(mu[1])), -2.0; atol=1e-10)
+end
+
+@testset "Discrete latents in valid support" begin
+    # Verify each sampled z[i] is in the Categorical support {1, 2}
+    mixture_def = @bugs begin
+        w[1] = 0.3
+        w[2] = 0.7
+        mu[1] ~ Normal(-2, 5)
+        mu[2] ~ Normal(2, 5)
+        sigma[1] ~ Exponential(1)
+        sigma[2] ~ Exponential(1)
+        for i in 1:N
+            z[i] ~ Categorical(w[1:2])
+            y[i] ~ Normal(mu[z[i]], sigma[z[i]])
+        end
+    end
+
+    data = (N=4, y=[-1.5, 2.3, -2.1, 1.8])
+    model = compile(mixture_def, data)
+    model = settrans(model, true)
+    model = set_evaluation_mode(model, UseAutoMarginalization())
+
+    test_params = [0.0, 0.0, 2.0, -2.0]
+
+    env = Base.invokelatest(
+        evaluate_and_sample_with_marginalization_values!!, model, test_params
+    )
+
+    @test AbstractPPL.getvalue(env, @varname(z[1])) in (1, 2)
+    @test AbstractPPL.getvalue(env, @varname(z[2])) in (1, 2)
+    @test AbstractPPL.getvalue(env, @varname(z[3])) in (1, 2)
+    @test AbstractPPL.getvalue(env, @varname(z[4])) in (1, 2)
+end
+
+@testset "Statistical correctness" begin
+    # Single discrete latent with all fixed parameters.
+    simple_def = @bugs begin
+        w[1] = 0.3
+        w[2] = 0.7
+        mu[1] = -3.0
+        mu[2] = 3.0
+        sigma = 1.0
+        z ~ Categorical(w[1:2])
+        y ~ Normal(mu[z], sigma)
+    end
+
+    data = (y=2.5,)
+    model = compile(simple_def, data)
+    model = settrans(model, true)
+    model = set_evaluation_mode(model, UseAutoMarginalization())
+
+    test_params = Float64[]
+
+    log_p1 = log(0.3) + logpdf(Normal(-3.0, 1.0), 2.5)
+    log_p2 = log(0.7) + logpdf(Normal(3.0, 1.0), 2.5)
+    p_z2_analytical = exp(log_p2) / (exp(log_p1) + exp(log_p2))
+
+    n_samples = 5000
+    z2_count = sum(
+        AbstractPPL.getvalue(
+            Base.invokelatest(
+                evaluate_and_sample_with_marginalization_values!!, model, test_params
+            ),
+            @varname(z),
+        ) == 2 for _ in 1:n_samples
+    )
+    p_z2_empirical = z2_count / n_samples
+
+    @test isapprox(p_z2_empirical, p_z2_analytical; atol=0.03)
+end
+
+@testset "Deterministic nodes recomputed" begin
+    # Deterministic node mean_val[i] = mu[z[i]] depends on the sampled z.
+    det_def = @bugs begin
+        w[1] = 0.5
+        w[2] = 0.5
+        mu[1] = -5.0
+        mu[2] = 5.0
+        sigma = 1.0
+        for i in 1:N
+            z[i] ~ Categorical(w[1:2])
+            mean_val[i] = mu[z[i]]
+            y[i] ~ Normal(mean_val[i], sigma)
+        end
+    end
+
+    data = (N=2, y=[-4.5, 4.8])
+    model = compile(det_def, data)
+    model = settrans(model, true)
+    model = set_evaluation_mode(model, UseAutoMarginalization())
+
+    test_params = Float64[]
+
+    env = Base.invokelatest(
+        evaluate_and_sample_with_marginalization_values!!, model, test_params
+    )
+
+    z1 = AbstractPPL.getvalue(env, @varname(z[1]))
+    z2 = AbstractPPL.getvalue(env, @varname(z[2]))
+    mv1 = AbstractPPL.getvalue(env, @varname(mean_val[1]))
+    mv2 = AbstractPPL.getvalue(env, @varname(mean_val[2]))
+
+    @test mv1 == (z1 == 1 ? -5.0 : 5.0)
+    @test mv2 == (z2 == 1 ? -5.0 : 5.0)
+end
+
+@testset "Partially observed z" begin
+    # Observed values must be preserved, unobserved must be in valid support.
+    mixture_def = @bugs begin
+        w[1] = 0.3
+        w[2] = 0.7
+        mu[1] ~ Normal(-2, 5)
+        mu[2] ~ Normal(2, 5)
+        sigma ~ Exponential(1)
+        for i in 1:N
+            z[i] ~ Categorical(w[1:2])
+            y[i] ~ Normal(mu[z[i]], sigma)
+        end
+    end
+
+    data = (N=4, y=[1.0, 2.0, -1.0, 3.0], z=[2, missing, 1, missing])
+    model = compile(mixture_def, data)
+    model = settrans(model, true)
+    model = set_evaluation_mode(model, UseAutoMarginalization())
+
+    test_params = [0.0, 2.0, -2.0]
+
+    env = Base.invokelatest(
+        evaluate_and_sample_with_marginalization_values!!, model, test_params
+    )
+
+    @test AbstractPPL.getvalue(env, @varname(z[1])) == 2
+    @test AbstractPPL.getvalue(env, @varname(z[3])) == 1
+
+    @test AbstractPPL.getvalue(env, @varname(z[2])) in (1, 2)
+    @test AbstractPPL.getvalue(env, @varname(z[4])) in (1, 2)
+end
+
+@testset "Joint HMM sampling" begin
+    # HMM with well-separated emissions.
+    hmm_def = @bugs begin
+        pi[1] = 0.5
+        pi[2] = 0.5
+        trans[1, 1] = 0.9
+        trans[1, 2] = 0.1
+        trans[2, 1] = 0.1
+        trans[2, 2] = 0.9
+        mu[1] = 0.0
+        mu[2] = 5.0
+        sigma = 1.0
+
+        z[1] ~ Categorical(pi[1:2])
+        for t in 2:T
+            p[t, 1] = trans[z[t - 1], 1]
+            p[t, 2] = trans[z[t - 1], 2]
+            z[t] ~ Categorical(p[t, :])
+        end
+
+        for t in 1:T
+            y[t] ~ Normal(mu[z[t]], sigma)
+        end
+    end
+
+    data = (T=4, y=[0.1, -0.2, 4.9, 5.1])
+    model = compile(hmm_def, data)
+    model = settrans(model, true)
+    model = set_evaluation_mode(model, UseAutoMarginalization())
+
+    test_params = Float64[]
+
+    env = Base.invokelatest(
+        evaluate_and_sample_with_marginalization_values!!, model, test_params
+    )
+    @test AbstractPPL.getvalue(env, @varname(z[1])) in (1, 2)
+    @test AbstractPPL.getvalue(env, @varname(z[2])) in (1, 2)
+    @test AbstractPPL.getvalue(env, @varname(z[3])) in (1, 2)
+    @test AbstractPPL.getvalue(env, @varname(z[4])) in (1, 2)
+
+    n_samples = 500
+    z1_is_1 = 0
+    z4_is_2 = 0
+    for _ in 1:n_samples
+        env = Base.invokelatest(
+            evaluate_and_sample_with_marginalization_values!!, model, test_params
+        )
+        AbstractPPL.getvalue(env, @varname(z[1])) == 1 && (z1_is_1 += 1)
+        AbstractPPL.getvalue(env, @varname(z[4])) == 2 && (z4_is_2 += 1)
+    end
+    @test z1_is_1 / n_samples > 0.8
+    @test z4_is_2 / n_samples > 0.8
+end
+
+@testset "No discrete variables" begin
+    # Should reconstruct params without error
+    continuous_def = @bugs begin
+        mu ~ Normal(0, 10)
+        sigma ~ Exponential(1)
+        for i in 1:N
+            y[i] ~ Normal(mu, sigma)
+        end
+    end
+
+    data = (N=3, y=[1.0, 2.0, 3.0])
+    model = compile(continuous_def, data)
+    model = settrans(model, true)
+    model = set_evaluation_mode(model, UseAutoMarginalization())
+
+    test_params = [0.0, 2.0]
+
+    env = Base.invokelatest(
+        evaluate_and_sample_with_marginalization_values!!, model, test_params
+    )
+
+    @test isapprox(AbstractPPL.getvalue(env, @varname(sigma)), 1.0; atol=1e-10)
+    @test isapprox(AbstractPPL.getvalue(env, @varname(mu)), 2.0; atol=1e-10)
+end
+
+@testset "GQ bypass" begin
+    gq_def = @bugs begin
+        w[1] = 0.5
+        w[2] = 0.5
+        mu[1] ~ Normal(0, 5)
+        mu[2] ~ Normal(0, 5)
+        sigma ~ Exponential(1)
+        for i in 1:N
+            z[i] ~ Categorical(w[1:2])
+            y[i] ~ Normal(mu[z[i]], sigma)
+        end
+        y_pred ~ Normal(mu[1], sigma)
+    end
+
+    data = (N=3, y=[1.0, -1.0, 2.0])
+    model = compile(gq_def, data)
+    model = settrans(model, true)
+    model = set_evaluation_mode(model, UseAutoMarginalization())
+
+    test_params = [0.0, 1.0, -1.0]
+
+    logp = Base.invokelatest(LogDensityProblems.logdensity, model, test_params)
+    @test isfinite(logp)
+
+    env = Base.invokelatest(
+        evaluate_and_sample_with_marginalization_values!!, model, test_params
+    )
+
+    @test isapprox(AbstractPPL.getvalue(env, @varname(sigma)), 1.0; atol=1e-10)
+    @test isapprox(AbstractPPL.getvalue(env, @varname(mu[1])), -1.0; atol=1e-10)
+    @test isapprox(AbstractPPL.getvalue(env, @varname(mu[2])), 1.0; atol=1e-10)
+    @test AbstractPPL.getvalue(env, @varname(z[1])) in (1, 2)
+    @test AbstractPPL.getvalue(env, @varname(z[2])) in (1, 2)
+    @test AbstractPPL.getvalue(env, @varname(z[3])) in (1, 2)
 end


### PR DESCRIPTION
#443 
4

- Added `evaluate_and_sample_with_marginalization_values` which reconstructs the discrete latent values by sampling from their conditional posteriors. 
- skips Stochastic nodes in `_marginalize_recursive` so models with stochastic nodes don't crash during auto marginalization.

- Also added necessary tests (might seem a little verbose and if wanted can refactor to make it less obtuse) 