### PR TITLE
2.5 Implement Forward sampling for generated quantities

### DIFF
--- a/JuliaBUGS/src/model/abstractppl.jl
+++ b/JuliaBUGS/src/model/abstractppl.jl
@@ -543,7 +543,7 @@ function _create_modified_model(
     base_model=nothing,
 )
     # Create new graph evaluation data preserving the original GQ classification
-    # We must explicitly keep the original `generated_quantities` to avoid them being reclassified.
+    # We must explicitly keep the original `generated_quantities` to avoid 
     original_gq = Set(generated_quantities(
         isnothing(model.base_model) ? model : model.base_model
     ))

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -546,6 +546,8 @@ params_vec = getparams(model, custom_env)
 params_dict = getparams(Dict, model, custom_env)
 ```
 """
+
+
 function getparams(model::BUGSModel, evaluation_env=model.evaluation_env)
     param_vars = _active_parameters(model)
 

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -58,6 +58,7 @@ function evaluate_with_rng!!(
     logprior = 0.0
     loglikelihood = 0.0
     evaluation_env = smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols)
+    sampled_vars = Set(model.graph_evaluation_data.model_parameters)
 
     for (i, vn) in enumerate(model.graph_evaluation_data.sorted_nodes)
         is_stochastic = model.graph_evaluation_data.is_stochastic_vals[i]
@@ -75,8 +76,12 @@ function evaluate_with_rng!!(
                 else
                     value = AbstractPPL.getvalue(model.evaluation_env, vn)
                 end
-            else
+            elseif vn in sampled_vars
                 value = rand(rng, dist)
+            else
+                # Postprocessed stochastic variables are excluded from the MCMC target.
+                # Keep current value deterministic during inference-time evaluation.
+                value = AbstractPPL.getvalue(evaluation_env, vn)
             end
 
             if transformed
@@ -91,7 +96,7 @@ function evaluate_with_rng!!(
 
             if is_observed
                 loglikelihood += logp
-            else
+            elseif vn in sampled_vars
                 logprior += logp
             end
 

--- a/JuliaBUGS/src/model/to_distribution.jl
+++ b/JuliaBUGS/src/model/to_distribution.jl
@@ -164,8 +164,9 @@ function Distributions.logpdf(d::BUGSModelDistribution, x::NamedTuple)
         )
         env = BangBang.setindex!!(env, AbstractPPL.getvalue(x, vn), vn)
     end
-    _, log_densities = evaluate_with_env!!(model, env; transformed=false)
-    # Untempered joint = logprior + loglikelihood, independent of any temperature default.
+    _, log_densities = evaluate_with_env!!(
+        model, env; transformed=false, include_generated_quantities=true
+    )
     return log_densities.logprior + log_densities.loglikelihood
 end
 

--- a/JuliaBUGS/src/source_gen.jl
+++ b/JuliaBUGS/src/source_gen.jl
@@ -252,13 +252,32 @@ function _lower_model_def_to_represent_observe_stmts(
     for statement in reconstructed_model_def.args
         if Meta.isexpr(statement, (:(=), :call))
             stmt_id = stmt_to_stmt_id[statement]
-            observed_loop_vars, model_parameter_loop_vars, deterministic_loop_vars = var_types[stmt_id]
+            observed_loop_vars, model_parameter_loop_vars, deterministic_loop_vars, generated_quantity_loop_vars = var_types[stmt_id]
 
             _contains_observed = !isempty(observed_loop_vars)
             _contains_model_parameter = !isempty(model_parameter_loop_vars)
+            _contains_generated_quantity = !isempty(generated_quantity_loop_vars)
 
             if _contains_observed
-                if _contains_model_parameter
+                if _contains_model_parameter && _contains_generated_quantity
+                    # Three-way: observed, model parameter, and GQ iterations
+                    MacroTools.@capture(statement, lhs_ ~ rhs_)
+                    new_stmt = MacroTools.@q if condition_placeholder
+                        $(lhs) ~ $(rhs)
+                    elseif observed_placeholder
+                        $(lhs) ≂ $(rhs)
+                    else
+                        $(lhs) ≃ $(rhs)
+                    end
+                    new_stmt.args[1] = __generate_model_parameter_condition_expr(
+                        model_parameter_loop_vars
+                    )
+                    # The elseif condition: check if current iteration is observed
+                    new_stmt.args[3].args[1] = __generate_model_parameter_condition_expr(
+                        observed_loop_vars
+                    )
+                    push!(lowered_model_def.args, new_stmt)
+                elseif _contains_model_parameter
                     MacroTools.@capture(statement, lhs_ ~ rhs_)
                     new_stmt = MacroTools.@q if condition_placeholder
                         $(lhs) ~ $(rhs)
@@ -269,11 +288,40 @@ function _lower_model_def_to_represent_observe_stmts(
                         model_parameter_loop_vars
                     )
                     push!(lowered_model_def.args, new_stmt)
+                elseif _contains_generated_quantity
+                    # Observed + GQ but no model parameters
+                    MacroTools.@capture(statement, lhs_ ~ rhs_)
+                    new_stmt = MacroTools.@q if condition_placeholder
+                        $(lhs) ≂ $(rhs)
+                    else
+                        $(lhs) ≃ $(rhs)
+                    end
+                    new_stmt.args[1] = __generate_model_parameter_condition_expr(
+                        observed_loop_vars
+                    )
+                    push!(lowered_model_def.args, new_stmt)
                 else
                     MacroTools.@capture(statement, lhs_ ~ rhs_)
                     new_stmt = MacroTools.@q $(lhs) ≂ $(rhs)
                     push!(lowered_model_def.args, new_stmt)
                 end
+            elseif _contains_generated_quantity && !_contains_model_parameter
+                # Pure generated quantity: forward-sample, no logp contribution
+                MacroTools.@capture(statement, lhs_ ~ rhs_)
+                new_stmt = MacroTools.@q $(lhs) ≃ $(rhs)
+                push!(lowered_model_def.args, new_stmt)
+            elseif _contains_generated_quantity && _contains_model_parameter
+                # Mixed: some iterations are MCMC parameters, some are GQ
+                MacroTools.@capture(statement, lhs_ ~ rhs_)
+                new_stmt = MacroTools.@q if condition_placeholder
+                    $(lhs) ~ $(rhs)
+                else
+                    $(lhs) ≃ $(rhs)
+                end
+                new_stmt.args[1] = __generate_model_parameter_condition_expr(
+                    model_parameter_loop_vars
+                )
+                push!(lowered_model_def.args, new_stmt)
             else
                 push!(lowered_model_def.args, statement)
             end
@@ -418,8 +466,14 @@ function _generate_lowered_model_def(
         sorted_fissioned_stmts
     )
     induction_variable_values = _var_to_loop_vars(model_def, evaluation_env)
+    gq_vars = find_generated_quantities_variables(g)
+    # If no observations exist, don't classify anything as GQ
+    has_observations = any(g[vn].is_observed for vn in labels(g) if g[vn].is_stochastic)
+    if !has_observations
+        gq_vars = Set{VarName}()
+    end
     var_types = __determine_var_types(
-        g, stmt_id_to_var, stmt_id_to_stmt, induction_variable_values
+        g, stmt_id_to_var, stmt_id_to_stmt, induction_variable_values, gq_vars
     )
     lowered_model_def = _lower_model_def_to_represent_observe_stmts(
         reconstructed_model_def, stmt_to_stmt_id, var_types, evaluation_env
@@ -492,21 +546,24 @@ function _var_to_loop_vars(model_def, evaluation_env)
 end
 
 function __determine_var_types(
-    g::JuliaBUGS.BUGSGraph, stmt_id_to_var, stmt_id_to_stmt, induction_variable_values
+    g::JuliaBUGS.BUGSGraph, stmt_id_to_var, stmt_id_to_stmt, induction_variable_values,
+    gq_vars::Set=Set{VarName}(),
 )
-    # for each statement, have three list to collect the var of each type
-    var_types = [([], [], []) for _ in 1:length(stmt_id_to_stmt)]
+    # for each statement, have four lists: observed, model_parameter, deterministic, generated_quantity
+    var_types = [([], [], [], []) for _ in 1:length(stmt_id_to_stmt)]
     for stmt_id in keys(stmt_id_to_stmt)
         if !haskey(stmt_id_to_var, stmt_id)
             continue
         end
         vars = stmt_id_to_var[stmt_id]
         for var in vars
-            var_type = __variable_type(g, var)
+            var_type = __variable_type(g, var, gq_vars)
             if var_type == :observed
                 push!(var_types[stmt_id][1], induction_variable_values[var])
             elseif var_type == :model_parameter
                 push!(var_types[stmt_id][2], induction_variable_values[var])
+            elseif var_type == :generated_quantity
+                push!(var_types[stmt_id][4], induction_variable_values[var])
             else
                 push!(var_types[stmt_id][3], induction_variable_values[var])
             end
@@ -515,10 +572,12 @@ function __determine_var_types(
     return var_types
 end
 
-function __variable_type(g::JuliaBUGS.BUGSGraph, var)
+function __variable_type(g::JuliaBUGS.BUGSGraph, var, gq_vars::Set=Set{VarName}())
     if g[var].is_stochastic
         if g[var].is_observed
             return :observed
+        elseif var in gq_vars
+            return :generated_quantity
         else
             return :model_parameter
         end
@@ -550,8 +609,12 @@ function __gen_logp_density_function_body_exprs(stmts::Vector, evaluation_env, e
         elseif Meta.isexpr(stmt, :call)
             if stmt.args[1] == :~
                 push!(exprs, __gen_model_parameter_exprs(stmt).args...)
-            else
+            elseif stmt.args[1] == :≂
                 push!(exprs, __gen_observe_exprs(stmt))
+            elseif stmt.args[1] == :≃
+                push!(exprs, __gen_generated_quantity_exprs(stmt))
+            else
+                error("Unknown operator: $(stmt.args[1])")
             end
         elseif Meta.isexpr(stmt, :for)
             new_body = __gen_logp_density_function_body_exprs(
@@ -604,6 +667,11 @@ end
 
 function __gen_deterministic_exprs(stmt)
     return stmt
+end
+
+function __gen_generated_quantity_exprs(stmt)
+    MacroTools.@capture(stmt, lhs_ ≃ rhs_)
+    return MacroTools.@q $lhs = rand($(rhs))
 end
 
 function __gen_model_parameter_exprs(stmt)

--- a/JuliaBUGS/test/model/to_distribution.jl
+++ b/JuliaBUGS/test/model/to_distribution.jl
@@ -82,41 +82,41 @@
         @test logpdf(d, nt) ≈ manual
     end
 
-    # @testset "partially observed array" begin
-    #    model_def = @bugs begin
-    #         for i in 1:4
-    #             x[i] ~ Normal(0, 1)
-    #         end
-    #     end
-    #     model = compile(model_def, (; x=[missing, 1.0, missing, 2.0]))
-    #     d = to_distribution(model)
+    @testset "partially observed array" begin
+        model_def = @bugs begin
+            for i in 1:4
+                x[i] ~ Normal(0, 1)
+            end
+        end
+        model = compile(model_def, (; x=[missing, 1.0, missing, 2.0]))
+        d = to_distribution(model)
 
-    #     # rand bakes the model's observed data into the observed slots.
-    #     nt = rand(MersenneTwister(0), d)
-    #     @test nt.x[2] == 1.0
-    #     @test nt.x[4] == 2.0
+        # rand bakes the model's observed data into the observed slots.
+        nt = rand(MersenneTwister(0), d)
+        @test nt.x[2] == 1.0
+        @test nt.x[4] == 2.0
 
-    #     # logpdf is the full joint, but the observed slots are scored against the MODEL's
-    #     # data, never against the caller's input: only the free parameters (x[1], x[3]) are
-    #     # read from the supplied NamedTuple. So logpdf is invariant to whatever sits in the
-    #     # observed slots (x[2], x[4]).
-    #     free1, free3 = nt.x[1], nt.x[3]
-    #     expected =
-    #         logpdf(Normal(0, 1), free1) +
-    #         logpdf(Normal(0, 1), free3) +    # free parameters x[1], x[3]
-    #         logpdf(Normal(0, 1), 1.0) +
-    #         logpdf(Normal(0, 1), 2.0)        # observed data x[2], x[4] (from the model)
-    #     @test logpdf(d, nt) ≈ expected
+        # logpdf is the full joint, but the observed slots are scored against the MODEL's
+        # data, never against the caller's input: only the free parameters (x[1], x[3]) are
+        # read from the supplied NamedTuple. So logpdf is invariant to whatever sits in the
+        # observed slots (x[2], x[4]).
+        free1, free3 = nt.x[1], nt.x[3]
+        expected =
+            logpdf(Normal(0, 1), free1) +
+            logpdf(Normal(0, 1), free3) +    # free parameters x[1], x[3]
+            logpdf(Normal(0, 1), 1.0) +
+            logpdf(Normal(0, 1), 2.0)        # observed data x[2], x[4] (from the model)
+        @test logpdf(d, nt) ≈ expected
 
-    #     # Tampering with the observed slots must not change the density (the bug: it did).
-    #     tampered = (; x=[free1, 999.0, free3, -888.0])
-    #     @test logpdf(d, tampered) ≈ expected
-    #     @test logpdf(d, tampered) ≈ logpdf(d, nt)
+        # Tampering with the observed slots must not change the density (the bug: it did).
+        tampered = (; x=[free1, 999.0, free3, -888.0])
+        @test logpdf(d, tampered) ≈ expected
+        @test logpdf(d, tampered) ≈ logpdf(d, nt)
 
-    #     # logpdf must not corrupt the model's stored data.
-    #     @test model.evaluation_env.x[2] == 1.0
-    #     @test model.evaluation_env.x[4] == 2.0
-    # end
+        # logpdf must not corrupt the model's stored data.
+        @test model.evaluation_env.x[2] == 1.0
+        @test model.evaluation_env.x[4] == 2.0
+    end
 
     @testset "mixed discrete/continuous" begin
         model_def = @bugs begin


### PR DESCRIPTION
#443 
2.5

blocked by: #490 

- implement forward sampling in `source_gen.jl`
- Updated `evaluate_with_rng!!` in `evaluation.jl` to allow forward sampling during the AST evaluation.
- Updated `to_distribution.jl` to pass `include_generated_quantities=true` when evaluating the density so joint density correctly incorporates the prior probabilities of the generated quantities.
- commented out tests are restored back.