### PR TITLE
Unify generated-quantity partition with a per-node mask

### DIFF
--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -69,6 +69,7 @@ Stores pre-computed values to avoid repeated lookups from the MetaGraph during m
 - `model_parameters::Vector{<:VarName}`: Unobserved stochastic variables that influence observations
 - `generated_quantities::Vector{<:VarName}`: Variables (stochastic or deterministic) with no observed descendants
 - `variable_types::Vector{VariableType}`: Classification of each node
+- `is_model_parameter_vals::Vector{Bool}`: Whether each node is part of the MCMC parameter vector (true exactly for `model_parameters`)
 - `is_stochastic_vals::Vector{Bool}`: Whether each node represents a stochastic variable
 - `is_observed_vals::Vector{Bool}`: Whether each node is observed (has data)
 - `node_function_vals::TNF`: Functions that define each node's computation
@@ -80,6 +81,7 @@ struct GraphEvaluationData{TNF,TV}
     model_parameters::Vector{<:VarName}
     generated_quantities::Vector{<:VarName}
     variable_types::Vector{VariableType}
+    is_model_parameter_vals::Vector{Bool}
     is_stochastic_vals::Vector{Bool}
     is_observed_vals::Vector{Bool}
     node_function_vals::TNF
@@ -108,6 +110,7 @@ function GraphEvaluationData(
     model_parameters = VarName[]
     generated_quantities = VarName[]
     variable_types = Vector{VariableType}(undef, length(sorted_nodes))
+    is_model_parameter_vals = fill(false, length(sorted_nodes))
 
     if gq_override !== nothing
         gq_vars = gq_override
@@ -141,6 +144,7 @@ function GraphEvaluationData(
             if active_parameters === nothing || vn in active_parameters
                 push!(sorted_parameters, vn)
                 push!(model_parameters, vn)
+                is_model_parameter_vals[i] = true
             end
         end
     end
@@ -151,6 +155,7 @@ function GraphEvaluationData(
         model_parameters,
         generated_quantities,
         variable_types,
+        is_model_parameter_vals,
         is_stochastic_vals,
         is_observed_vals,
         map(identity, node_function_vals),
@@ -322,7 +327,6 @@ function BUGSModel(
     untransformed_param_length, transformed_param_length = 0, 0
     untransformed_var_lengths, transformed_var_lengths = Dict{VarName,Int}(),
     Dict{VarName,Int}()
-    sampled_vars = Set(graph_evaluation_data.model_parameters)
 
     for (i, vn) in enumerate(graph_evaluation_data.sorted_nodes)
         is_stochastic = graph_evaluation_data.is_stochastic_vals[i]
@@ -347,7 +351,7 @@ function BUGSModel(
                 else
                     length(Bijectors.transformed(dist))
                 end
-                if vn in sampled_vars
+                if graph_evaluation_data.is_model_parameter_vals[i]
                     untransformed_param_length += untransformed_var_lengths[vn]
                     transformed_param_length += transformed_var_lengths[vn]
                 end
@@ -420,7 +424,8 @@ Return the `VariableType` classification for variable `vn` in the model.
 function variable_type(model::BUGSModel, vn::VarName)
     gd = model.graph_evaluation_data
     idx = findfirst(==(vn), gd.sorted_nodes)
-    idx === nothing && throw(ArgumentError("Variable \"$(vn)\" does not exist in the model"))
+    idx === nothing &&
+        throw(ArgumentError("Variable \"$(vn)\" does not exist in the model"))
     return gd.variable_types[idx]
 end
 

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -54,6 +54,7 @@ function evaluate_with_rng!!(
     sample_observed=false,
     temperature=1.0,
     transformed=true,
+    include_generated_quantities=false,
 )
     logprior = 0.0
     loglikelihood = 0.0
@@ -91,7 +92,8 @@ function evaluate_with_rng!!(
 
             if is_observed
                 loglikelihood += logp
-            else
+            elseif include_generated_quantities ||
+                model.graph_evaluation_data.is_model_parameter_vals[i]
                 logprior += logp
             end
 
@@ -135,11 +137,6 @@ function evaluate_with_env!!(
 )
     logprior = 0.0
     loglikelihood = 0.0
-    sampled_vars = if include_generated_quantities
-        Set(model.graph_evaluation_data.sorted_parameters)
-    else
-        Set(model.graph_evaluation_data.model_parameters)
-    end
 
     for (i, vn) in enumerate(model.graph_evaluation_data.sorted_nodes)
         is_stochastic = model.graph_evaluation_data.is_stochastic_vals[i]
@@ -169,7 +166,8 @@ function evaluate_with_env!!(
 
             if is_observed
                 loglikelihood += logp
-            elseif vn in sampled_vars
+            elseif include_generated_quantities ||
+                model.graph_evaluation_data.is_model_parameter_vals[i]
                 logprior += logp
             end
         end
@@ -213,7 +211,6 @@ function evaluate_with_values!!(
     end
 
     evaluation_env = smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols)
-    sampled_vars = Set(model.graph_evaluation_data.model_parameters)
     current_idx = 1
     logprior, loglikelihood = 0.0, 0.0
     for (i, vn) in enumerate(model.graph_evaluation_data.sorted_nodes)
@@ -224,38 +221,33 @@ function evaluate_with_values!!(
         if !is_stochastic
             value = node_function(evaluation_env, loop_vars)
             evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
+        elseif !is_observed && model.graph_evaluation_data.is_model_parameter_vals[i]
+            dist = node_function(evaluation_env, loop_vars)
+            l = var_lengths[vn]
+            if transformed
+                b = Bijectors.bijector(dist)
+                b_inv = Bijectors.inverse(b)
+                reconstructed_value = reconstruct(
+                    b_inv, dist, view(flattened_values, current_idx:(current_idx + l - 1))
+                )
+                value, logjac = Bijectors.with_logabsdet_jacobian(
+                    b_inv, reconstructed_value
+                )
+            else
+                value = reconstruct(
+                    dist, view(flattened_values, current_idx:(current_idx + l - 1))
+                )
+                logjac = 0.0
+            end
+            current_idx += l
+            logprior += logpdf(dist, value) + logjac
+            evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
+        elseif !is_observed
+            # Generated quantity: not part of the MCMC parameter vector. Leave its
+            # current env value untouched here; it is forward-sampled separately.
         else
             dist = node_function(evaluation_env, loop_vars)
-            if !is_observed && vn in sampled_vars
-                l = var_lengths[vn]
-                if transformed
-                    b = Bijectors.bijector(dist)
-                    b_inv = Bijectors.inverse(b)
-                    reconstructed_value = reconstruct(
-                        b_inv,
-                        dist,
-                        view(flattened_values, current_idx:(current_idx + l - 1)),
-                    )
-                    value, logjac = Bijectors.with_logabsdet_jacobian(
-                        b_inv, reconstructed_value
-                    )
-                else
-                    value = reconstruct(
-                        dist, view(flattened_values, current_idx:(current_idx + l - 1))
-                    )
-                    logjac = 0.0
-                end
-                current_idx += l
-                logprior += logpdf(dist, value) + logjac
-                evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
-            elseif !is_observed
-                # Postprocessed stochastic variables are not part of parameter vectors
-                # and should not contribute to the sampled target density.
-                value = AbstractPPL.getvalue(evaluation_env, vn)
-                evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
-            else
-                loglikelihood += logpdf(dist, AbstractPPL.getvalue(evaluation_env, vn))
-            end
+            loglikelihood += logpdf(dist, AbstractPPL.getvalue(evaluation_env, vn))
         end
     end
     return evaluation_env,
@@ -297,9 +289,8 @@ end
 Return the finite support for a discrete univariate distribution.
 Relies on Distributions.support to provide an iterable, finite range.
 """
-_enumerate_discrete_values(dist::Distributions.DiscreteUnivariateDistribution) = Distributions.support(
-    dist
-)
+_enumerate_discrete_values(dist::Distributions.DiscreteUnivariateDistribution) =
+    Distributions.support(dist)
 
 """
     _classify_node_type(dist)

--- a/JuliaBUGS/src/model/logdensityproblems.jl
+++ b/JuliaBUGS/src/model/logdensityproblems.jl
@@ -31,18 +31,27 @@ function LogDensityProblems.logdensity(model::BUGSModel, x::AbstractArray)
 end
 
 function LogDensityProblems.dimension(model::BUGSModel)
-    param_vars = _active_parameters(model)
-    dim = 0
-    if model.transformed
-        for vn in param_vars
-            dim += model.transformed_var_lengths[vn]
+    # Auto-marginalization needs the continuous-only filter; other modes can use the
+    # precomputed parameter lengths (already accumulated over `model_parameters`).
+    if model.evaluation_mode isa UseAutoMarginalization
+        param_vars = _active_parameters(model)
+        dim = 0
+        if model.transformed
+            for vn in param_vars
+                dim += model.transformed_var_lengths[vn]
+            end
+        else
+            for vn in param_vars
+                dim += model.untransformed_var_lengths[vn]
+            end
         end
-    else
-        for vn in param_vars
-            dim += model.untransformed_var_lengths[vn]
-        end
+        return dim
     end
-    return dim
+    return if model.transformed
+        model.transformed_param_length
+    else
+        model.untransformed_param_length
+    end
 end
 
 function LogDensityProblems.capabilities(::AbstractBUGSModel)

--- a/JuliaBUGS/test/model/bugsmodel.jl
+++ b/JuliaBUGS/test/model/bugsmodel.jl
@@ -205,6 +205,64 @@ end
         @test @varname(mean_x) ∉ gq
     end
 
+    @testset "MCMC partition excludes generated quantities" begin
+        # mu drives the likelihood (model parameter); z is a stochastic generated
+        # quantity (no observed descendant); pred is a deterministic generated quantity.
+        model_def = @bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            z ~ Normal(mu, 1)
+            pred = mu + 1.0
+        end
+        model = compile(model_def, (; y=0.5))
+
+        # Only the model parameter enters the MCMC parameter vector.
+        @test model_parameters(model) == [@varname(mu)]
+        @test @varname(z) in generated_quantities(model)
+        @test @varname(pred) in generated_quantities(model)
+        @test LogDensityProblems.dimension(model) == 1
+        @test length(getparams(model)) == 1
+
+        # `parameters` (all unobserved stochastic) still includes the stochastic GQ, so
+        # it now legitimately differs in length from the MCMC dimension.
+        @test @varname(z) in parameters(model)
+        @test length(parameters(model)) != LogDensityProblems.dimension(model)
+
+        # The dimension fast path agrees with the precomputed length field.
+        @test LogDensityProblems.dimension(model) == model.transformed_param_length
+
+        x = getparams(model)
+        env, logp = AbstractPPL.evaluate!!(model, x)
+        model_env = JuliaBUGS.Accessors.@set model.evaluation_env = env
+
+        # GQ-exclusion invariant: the MCMC target equals the full joint minus the
+        # generated-quantity prior terms.
+        _, ld_excl = JuliaBUGS.Model.evaluate_with_env!!(
+            model_env; transformed=model.transformed, include_generated_quantities=false
+        )
+        _, ld_incl = JuliaBUGS.Model.evaluate_with_env!!(
+            model_env; transformed=model.transformed, include_generated_quantities=true
+        )
+        z_logp = logpdf(
+            Normal(AbstractPPL.getvalue(env, @varname(mu)), 1),
+            AbstractPPL.getvalue(env, @varname(z)),
+        )
+        @test ld_incl.logprior - ld_excl.logprior ≈ z_logp
+        @test logp ≈ ld_excl.logprior + ld_excl.loglikelihood
+
+        # Regression for the env/rng acceptance inconsistency: the ancestral proposal
+        # and the env recompute use the same GQ policy, so they agree on the same env.
+        rng = StableRNG(123)
+        env_rng, ld_rng = JuliaBUGS.Model.evaluate_with_rng!!(
+            rng, model; transformed=model.transformed
+        )
+        model_rng = JuliaBUGS.Accessors.@set model.evaluation_env = env_rng
+        _, ld_rng_env = JuliaBUGS.Model.evaluate_with_env!!(
+            model_rng; transformed=model.transformed, include_generated_quantities=false
+        )
+        @test ld_rng.tempered_logjoint ≈ ld_rng_env.tempered_logjoint
+    end
+
     @testset "initialize!" begin
         model_def = @bugs begin
             a ~ Normal(0, 1)


### PR DESCRIPTION
Stacked on #490 (targets `variabletype_enum`).

## Summary
#490 routed the MCMC machinery to `model_parameters`, but implemented the split by rebuilding `Set`s of `VarName`s on every evaluation and with three divergent generated-quantity (GQ) conventions across the `evaluate_*!!` functions. This PR collapses that to a single source of truth and fixes a latent correctness bug in the process.

### Correctness fix
`evaluate_with_env!!` (the *current* log density in Gibbs/IndependentMH) excluded GQ priors, while `evaluate_with_rng!!` (the *proposed* log density) included them. The unmatched GQ-prior term biased the Metropolis acceptance ratio for `Gibbs` + `IndependentMH`. Unifying the policy removes the asymmetry.

### Changes
- Add `is_model_parameter_vals::Vector{Bool}` to `GraphEvaluationData`, set at the `model_parameters` push site so it respects `active_parameters`. Single source of truth for "is this node part of the MCMC parameter vector".
- `evaluate_with_values!!`, `evaluate_with_env!!`, `evaluate_with_rng!!` consult the mask instead of allocating a `Set` per call, behind a unified `include_generated_quantities` flag. `evaluate_with_rng!!` gains the flag (default `false`).
- `evaluate_with_values!!` skips GQ before constructing their distribution and drops the dead read-then-write-back branch.
- `LogDensityProblems.dimension` returns the precomputed `*_param_length` scalar for non-marginalization modes (O(1)); marginalization keeps the continuous-only filter.
- New testset: partition behavior, the GQ-exclusion invariant (`logdensity == joint − Σ GQ priors`), and the rng/env acceptance-policy consistency regression.

### Behavior
Behavior-preserving for the log density and parameter-vector layout. Net effects: fixes the Gibbs/IndependentMH acceptance inconsistency, and removes per-call `Set` allocations plus a redundant per-call `dimension` recompute from the hot evaluation path.

## Testing
Green locally across `compilation_model`, `model_operations`, `log_density` (incl. `ad_compatibility`, `auto_marginalization`, `to_distribution`), `gibbs`, `inference_mh`, `inference_chains`, `inference_hmc`, `inference_marginalization`, `callbacks`. JuliaFormatter-clean.

This is the refactor step of a two-step plan; the follow-up will add forward-sampling of generated quantities (`forward_sample_generated_quantities!!` + `gen_chains` rng pass + `to_distribution` full joint).

https://claude.ai/code/session_01X2Ew8Yzg9A28nwarYkgAhe