### PR TITLE
Forward-sample generated quantities

### DIFF
--- a/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
@@ -8,10 +8,11 @@ using JuliaBUGS:
     find_generated_quantities_variables,
     evaluate!!,
     getparams
-using JuliaBUGS.Model: UseAutoMarginalization, model_parameters
+using JuliaBUGS.Model: model_parameters, forward_sample_generated_quantities!!
 using JuliaBUGS.AbstractPPL
 using JuliaBUGS.Accessors
 using MCMCChains: Chains
+using Random: default_rng
 
 function JuliaBUGS.gen_chains(
     model::AbstractMCMC.LogDensityModel{<:BUGSModel},
@@ -127,6 +128,7 @@ function JuliaBUGS.gen_chains(
     samples,
     stats_names,
     stats_values;
+    rng=default_rng(),
     discard_initial=0,
     thinning=1,
     kwargs...,
@@ -135,8 +137,8 @@ function JuliaBUGS.gen_chains(
     # Filter parameters based on evaluation mode and MCMC partition.
     param_vars = model_parameters(model)
 
-    # Find and order generated quantities
-    # Exclude parameters to avoid double counting forward-sampled variables
+    # Generated quantities (no observed descendants) are reported in topological order;
+    # they are disjoint from the model parameters by construction.
     generated_vars = find_generated_quantities_variables(model.g)
     param_set = Set(param_vars)
     generated_vars = [v for v in gd.sorted_nodes if v in generated_vars && v ∉ param_set]
@@ -147,6 +149,11 @@ function JuliaBUGS.gen_chains(
     for i in axes(samples)[1]
         # Set parameters and evaluate the model
         evaluation_env = first(evaluate!!(model, samples[i]))
+
+        # Forward-sample the stochastic generated quantities (and recompute deterministic
+        # ones) for this draw, so the reported values are genuine posterior-predictive
+        # draws rather than the stale environment values left by `evaluate!!`.
+        evaluation_env = forward_sample_generated_quantities!!(rng, model, evaluation_env)
 
         # Get parameter values from the evaluation environment
         # (they were just set by evaluate!!, so they match samples[i])

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -258,6 +258,48 @@ function evaluate_with_values!!(
     )
 end
 
+"""
+    forward_sample_generated_quantities!!(
+        rng::Random.AbstractRNG,
+        model::BUGSModel,
+        evaluation_env=smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols),
+    )
+
+Forward-sample the generated quantities of `model` given an environment that already holds
+the model parameters, observations, and transformed parameters.
+
+Generated quantities are the nodes with no observed descendants. Stochastic ones are drawn
+from their conditional distribution given their (already-set) parents (`rand`); deterministic
+ones are recomputed. Model parameters, observations, and transformed parameters are left
+untouched. Nodes are visited in topological order, so chains of generated quantities are
+sampled with their parents already in place.
+
+This is the post-processing step that turns a posterior draw of the model parameters into a
+joint posterior(-predictive) draw that also includes the generated quantities.
+
+# Returns
+- `evaluation_env`: The environment with generated-quantity values filled in.
+"""
+function forward_sample_generated_quantities!!(
+    rng::Random.AbstractRNG,
+    model::BUGSModel,
+    evaluation_env=smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols),
+)
+    gd = model.graph_evaluation_data
+    for (i, vn) in enumerate(gd.sorted_nodes)
+        gd.variable_types[i] == GeneratedQuantity || continue
+        node_function = gd.node_function_vals[i]
+        loop_vars = gd.loop_vars_vals[i]
+        value = if gd.is_stochastic_vals[i]
+            rand(rng, node_function(evaluation_env, loop_vars))
+        else
+            node_function(evaluation_env, loop_vars)
+        end
+        evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
+    end
+    return evaluation_env
+end
+
 # ======================
 # Marginalization Support
 # ======================

--- a/JuliaBUGS/src/model/to_distribution.jl
+++ b/JuliaBUGS/src/model/to_distribution.jl
@@ -164,7 +164,12 @@ function Distributions.logpdf(d::BUGSModelDistribution, x::NamedTuple)
         )
         env = BangBang.setindex!!(env, AbstractPPL.getvalue(x, vn), vn)
     end
-    _, log_densities = evaluate_with_env!!(model, env; transformed=false)
+    # `parameters` spans all unobserved stochastic nodes (model parameters and stochastic
+    # generated quantities), so the joint must score every one of them — include the
+    # generated-quantity priors that the evaluation otherwise drops by default.
+    _, log_densities = evaluate_with_env!!(
+        model, env; transformed=false, include_generated_quantities=true
+    )
     # Untempered joint = logprior + loglikelihood, independent of any temperature default.
     return log_densities.logprior + log_densities.loglikelihood
 end

--- a/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
@@ -130,3 +130,35 @@
         Symbol("A[1, 1:3][3]"),
     ])
 end
+
+@testset "forward-sampled generated quantities in chains" begin
+    model_def = @bugs begin
+        mu ~ dnorm(0, 1)
+        y ~ dnorm(mu, 1)
+        z ~ dnorm(mu, 1)      # stochastic generated quantity
+        pred = mu + 1.0       # deterministic generated quantity
+    end
+    model = compile(model_def, (; y=0.5))
+    @test LogDensityProblems.dimension(model) == 1
+
+    # Synthetic posterior draws of the single model parameter `mu`.
+    samples = [[m] for m in range(-1.0, 1.0; length=25)]
+    chn = JuliaBUGS.gen_chains(model, samples, Symbol[], []; rng=StableRNG(2024))
+
+    colnames = names(chn)
+    @test :mu in colnames
+    @test :z in colnames       # stochastic generated quantity surfaced
+    @test :pred in colnames    # deterministic generated quantity surfaced
+
+    A = Array(chn)
+    mucol = A[:, findfirst(==(:mu), colnames)]
+    zcol = A[:, findfirst(==(:z), colnames)]
+    predcol = A[:, findfirst(==(:pred), colnames)]
+
+    # Stochastic generated quantity is forward-sampled, not frozen at one value.
+    @test length(unique(zcol)) > 1
+    # Deterministic generated quantity equals f(model parameter) for every draw.
+    @test all(predcol .≈ mucol .+ 1.0)
+    # Model-parameter column matches the synthetic samples in order.
+    @test mucol ≈ [s[1] for s in samples]
+end

--- a/JuliaBUGS/test/model/evaluation.jl
+++ b/JuliaBUGS/test/model/evaluation.jl
@@ -668,3 +668,36 @@ end
         @test isa(logp, Real)
     end
 end
+
+@testset "forward_sample_generated_quantities!!" begin
+    model_def = @bugs begin
+        mu ~ Normal(0, 1)
+        y ~ Normal(mu, 1)
+        z ~ Normal(mu, 1)       # stochastic generated quantity
+        z2 ~ Normal(z, 1)       # chained stochastic generated quantity
+        pred = mu + 1.0         # deterministic generated quantity
+    end
+    model = compile(model_def, (; y=0.5))
+    fsgq = JuliaBUGS.Model.forward_sample_generated_quantities!!
+
+    base_env, _ = AbstractPPL.evaluate!!(model, JuliaBUGS.getparams(model))
+    mu0 = AbstractPPL.getvalue(base_env, @varname(mu))
+
+    e1 = fsgq(StableRNG(1), model, deepcopy(base_env))
+    e2 = fsgq(StableRNG(2), model, deepcopy(base_env))
+    e1b = fsgq(StableRNG(1), model, deepcopy(base_env))
+
+    # Model parameter and observation are left untouched.
+    @test AbstractPPL.getvalue(e1, @varname(mu)) == mu0
+    @test AbstractPPL.getvalue(e1, @varname(y)) == 0.5
+
+    # Stochastic generated quantities are redrawn; different rng -> different values.
+    @test AbstractPPL.getvalue(e1, @varname(z)) != AbstractPPL.getvalue(e2, @varname(z))
+    @test AbstractPPL.getvalue(e1, @varname(z2)) != AbstractPPL.getvalue(e2, @varname(z2))
+
+    # Same rng -> identical draws.
+    @test AbstractPPL.getvalue(e1, @varname(z)) == AbstractPPL.getvalue(e1b, @varname(z))
+
+    # Deterministic generated quantity is recomputed from its (sampled) parents.
+    @test AbstractPPL.getvalue(e1, @varname(pred)) ≈ mu0 + 1.0
+end

--- a/JuliaBUGS/test/model/to_distribution.jl
+++ b/JuliaBUGS/test/model/to_distribution.jl
@@ -82,41 +82,41 @@
         @test logpdf(d, nt) ≈ manual
     end
 
-    # @testset "partially observed array" begin
-    #    model_def = @bugs begin
-    #         for i in 1:4
-    #             x[i] ~ Normal(0, 1)
-    #         end
-    #     end
-    #     model = compile(model_def, (; x=[missing, 1.0, missing, 2.0]))
-    #     d = to_distribution(model)
+    @testset "partially observed array" begin
+        model_def = @bugs begin
+            for i in 1:4
+                x[i] ~ Normal(0, 1)
+            end
+        end
+        model = compile(model_def, (; x=[missing, 1.0, missing, 2.0]))
+        d = to_distribution(model)
 
-    #     # rand bakes the model's observed data into the observed slots.
-    #     nt = rand(MersenneTwister(0), d)
-    #     @test nt.x[2] == 1.0
-    #     @test nt.x[4] == 2.0
+        # rand bakes the model's observed data into the observed slots.
+        nt = rand(MersenneTwister(0), d)
+        @test nt.x[2] == 1.0
+        @test nt.x[4] == 2.0
 
-    #     # logpdf is the full joint, but the observed slots are scored against the MODEL's
-    #     # data, never against the caller's input: only the free parameters (x[1], x[3]) are
-    #     # read from the supplied NamedTuple. So logpdf is invariant to whatever sits in the
-    #     # observed slots (x[2], x[4]).
-    #     free1, free3 = nt.x[1], nt.x[3]
-    #     expected =
-    #         logpdf(Normal(0, 1), free1) +
-    #         logpdf(Normal(0, 1), free3) +    # free parameters x[1], x[3]
-    #         logpdf(Normal(0, 1), 1.0) +
-    #         logpdf(Normal(0, 1), 2.0)        # observed data x[2], x[4] (from the model)
-    #     @test logpdf(d, nt) ≈ expected
+        # logpdf is the full joint, but the observed slots are scored against the MODEL's
+        # data, never against the caller's input: only the free parameters (x[1], x[3]) are
+        # read from the supplied NamedTuple. So logpdf is invariant to whatever sits in the
+        # observed slots (x[2], x[4]).
+        free1, free3 = nt.x[1], nt.x[3]
+        expected =
+            logpdf(Normal(0, 1), free1) +
+            logpdf(Normal(0, 1), free3) +    # free parameters x[1], x[3]
+            logpdf(Normal(0, 1), 1.0) +
+            logpdf(Normal(0, 1), 2.0)        # observed data x[2], x[4] (from the model)
+        @test logpdf(d, nt) ≈ expected
 
-    #     # Tampering with the observed slots must not change the density (the bug: it did).
-    #     tampered = (; x=[free1, 999.0, free3, -888.0])
-    #     @test logpdf(d, tampered) ≈ expected
-    #     @test logpdf(d, tampered) ≈ logpdf(d, nt)
+        # Tampering with the observed slots must not change the density (the bug: it did).
+        tampered = (; x=[free1, 999.0, free3, -888.0])
+        @test logpdf(d, tampered) ≈ expected
+        @test logpdf(d, tampered) ≈ logpdf(d, nt)
 
-    #     # logpdf must not corrupt the model's stored data.
-    #     @test model.evaluation_env.x[2] == 1.0
-    #     @test model.evaluation_env.x[4] == 2.0
-    # end
+        # logpdf must not corrupt the model's stored data.
+        @test model.evaluation_env.x[2] == 1.0
+        @test model.evaluation_env.x[4] == 2.0
+    end
 
     @testset "mixed discrete/continuous" begin
         model_def = @bugs begin


### PR DESCRIPTION
## Summary
Generated quantities (stochastic or deterministic nodes with no observed descendants) are excluded from the MCMC parameter vector. But stochastic ones were still reported at their **stale initial value** in the chains, and `to_distribution`'s joint silently dropped their prior. This PR adds the forward-sampling step so generated quantities become genuine posterior-predictive draws.

### Changes
- **`forward_sample_generated_quantities!!(rng, model, env)`** — a topological pass that draws each stochastic generated quantity from its conditional given its already-set parents (`rand`) and recomputes deterministic ones. Model parameters, observations, and transformed parameters are left untouched, so it turns a posterior draw of the model parameters into a full joint posterior-predictive draw.
- **`gen_chains`** gains an `rng` keyword and runs the forward pass per draw, so stochastic generated-quantity columns vary across iterations instead of being frozen at the compile-time value.
- **`to_distribution`** — `logpdf` scores the full joint again (`include_generated_quantities=true`), consistent with `rand` and `parameters`. Restores the previously-disabled `partially observed array` test.
- Drop the now-unused `UseAutoMarginalization` import in the MCMCChains extension.

### Tests
- Unit test for the primitive: redraw under different RNG, determinism under the same RNG, deterministic GQ recomputed from sampled parents, model parameters/observations untouched.
- `gen_chains` test: the stochastic generated-quantity column varies across draws, the deterministic generated quantity equals `f(parameters)` per draw, and the parameter column matches the input samples.

## Testing
Green locally across `compilation_model`, `model_operations`, `log_density` (incl. `to_distribution`), `gibbs`, `inference_mh`, `inference_chains`, `inference_hmc`. JuliaFormatter-clean.

## Notes / follow-ups (not in this PR)
- `gen_chains` defaults `rng` to `Random.default_rng()` because `AbstractMCMC.bundle_samples` does not thread the sampler RNG; making forward-sampled GQ seed-reproducible from `sample(...)` is a separate change.
- Generated-function (`UseGeneratedLogDensityFunction`) and auto-marginalization modes are unchanged here — the generated-function path still falls back to graph evaluation when generated quantities are present.

https://claude.ai/code/session_01X2Ew8Yzg9A28nwarYkgAhe