### PR TITLE
Support generated quantities in the generated log-density function

### DIFF
--- a/JuliaBUGS/src/model/abstractppl.jl
+++ b/JuliaBUGS/src/model/abstractppl.jl
@@ -544,9 +544,9 @@ function _create_modified_model(
 )
     # Create new graph evaluation data preserving the original GQ classification
     # We must explicitly keep the original `generated_quantities` to avoid them being reclassified.
-    original_gq = Set(generated_quantities(
-        isnothing(model.base_model) ? model : model.base_model
-    ))
+    original_gq = Set(
+        generated_quantities(isnothing(model.base_model) ? model : model.base_model)
+    )
     new_graph_evaluation_data = GraphEvaluationData(new_graph; gq_override=original_gq)
     new_parameters = new_graph_evaluation_data.model_parameters
 
@@ -591,7 +591,10 @@ function _regenerate_log_density_function(
     graph_evaluation_data::GraphEvaluationData,
 )
     lowered_model_def, reconstructed_model_def = JuliaBUGS._generate_lowered_model_def(
-        model_def, graph, evaluation_env
+        model_def,
+        graph,
+        evaluation_env;
+        generated_quantities=Set(graph_evaluation_data.generated_quantities),
     )
 
     if !isnothing(lowered_model_def)
@@ -611,9 +614,15 @@ function _regenerate_log_density_function(
             node in graph_evaluation_data.sorted_nodes
         end
 
-        # Update graph evaluation data with the correct sorted nodes
+        # Update graph evaluation data with the correct sorted nodes. Preserve the same
+        # generated-quantity classification that was used to generate the function above;
+        # otherwise the 3-argument constructor would re-derive it from the (possibly
+        # conditioned) graph and disagree with the generated code.
         updated_graph_evaluation_data = GraphEvaluationData(
-            graph, sorted_nodes, graph_evaluation_data.model_parameters
+            graph,
+            sorted_nodes,
+            graph_evaluation_data.model_parameters;
+            gq_override=Set(graph_evaluation_data.generated_quantities),
         )
 
         return new_log_density_computation_function, updated_graph_evaluation_data

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -672,7 +672,10 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
         # Lazily generate log density function if not already present
         if isnothing(model.log_density_computation_function)
             lowered_model_def, reconstructed_model_def = JuliaBUGS._generate_lowered_model_def(
-                model.model_def, model.g, model.evaluation_env
+                model.model_def,
+                model.g,
+                model.evaluation_env;
+                generated_quantities=Set(model.graph_evaluation_data.generated_quantities),
             )
             if isnothing(lowered_model_def)
                 @warn(
@@ -700,9 +703,16 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                     node in gd.sorted_nodes
                 end
 
-                # Create fresh GraphEvaluationData for the new order
+                # Create fresh GraphEvaluationData for the new order. Preserve the same
+                # generated-quantity classification used to generate the function above so
+                # the stored data and the generated code agree (the 3-argument constructor
+                # would otherwise re-derive GQ from the graph and disagree on, e.g.,
+                # conditioned models).
                 new_gd = GraphEvaluationData(
-                    model.g, sorted_nodes, model.graph_evaluation_data.model_parameters
+                    model.g,
+                    sorted_nodes,
+                    model.graph_evaluation_data.model_parameters;
+                    gq_override=Set(model.graph_evaluation_data.generated_quantities),
                 )
 
                 model = BangBang.setproperty!!(model, :graph_evaluation_data, new_gd)

--- a/JuliaBUGS/src/model/logdensityproblems.jl
+++ b/JuliaBUGS/src/model/logdensityproblems.jl
@@ -1,10 +1,6 @@
 using LogDensityProblems
 
 function _eval_logdensity(model, ::UseGeneratedLogDensityFunction, x)
-    if !isempty(model.graph_evaluation_data.generated_quantities)
-        _, log_densities = evaluate_with_values!!(model, x; transformed=model.transformed)
-        return log_densities.tempered_logjoint
-    end
     return Base.invokelatest(
         model.log_density_computation_function, model.evaluation_env, x
     )

--- a/JuliaBUGS/src/source_gen.jl
+++ b/JuliaBUGS/src/source_gen.jl
@@ -252,12 +252,26 @@ function _lower_model_def_to_represent_observe_stmts(
     for statement in reconstructed_model_def.args
         if Meta.isexpr(statement, (:(=), :call))
             stmt_id = stmt_to_stmt_id[statement]
-            observed_loop_vars, model_parameter_loop_vars, deterministic_loop_vars = var_types[stmt_id]
+            observed_loop_vars, model_parameter_loop_vars, generated_quantity_loop_vars, deterministic_loop_vars = var_types[stmt_id]
 
             _contains_observed = !isempty(observed_loop_vars)
             _contains_model_parameter = !isempty(model_parameter_loop_vars)
+            _contains_generated_quantity = !isempty(generated_quantity_loop_vars)
 
-            if _contains_observed
+            if _contains_generated_quantity
+                # Generated-quantity iterations are forward-sampled in post-processing and
+                # must not enter the log density. Emit code only for the model-parameter,
+                # observed, and kept-deterministic iterations; generated-quantity
+                # iterations fall through. A statement that is entirely generated
+                # quantities is dropped.
+                new_stmt = __lower_stmt_with_generated_quantities(
+                    statement,
+                    observed_loop_vars,
+                    model_parameter_loop_vars,
+                    deterministic_loop_vars,
+                )
+                isnothing(new_stmt) || push!(lowered_model_def.args, new_stmt)
+            elseif _contains_observed
                 if _contains_model_parameter
                     MacroTools.@capture(statement, lhs_ ~ rhs_)
                     new_stmt = MacroTools.@q if condition_placeholder
@@ -330,6 +344,61 @@ function __generate_model_parameter_condition_expr(model_param_nt_vec)
     end
 end
 
+# Lower a statement that has generated-quantity iterations. Generated quantities never
+# contribute to the log density (stochastic ones are forward-sampled, deterministic ones
+# recomputed, in post-processing), so the emitted code guards the surviving categories
+# with explicit per-iteration conditions and lets generated-quantity iterations fall
+# through. Returns `nothing` when the whole statement is generated quantities.
+function __lower_stmt_with_generated_quantities(
+    statement, observed_loop_vars, model_parameter_loop_vars, deterministic_loop_vars
+)
+    if Meta.isexpr(statement, :call)
+        # Stochastic `~` statement: keep model-parameter (`~`) and observed (`≂`) iterations.
+        MacroTools.@capture(statement, lhs_ ~ rhs_)
+        has_model_parameter = !isempty(model_parameter_loop_vars)
+        has_observed = !isempty(observed_loop_vars)
+        tilde_stmt = MacroTools.@q $(lhs) ~ $(rhs)
+        observe_stmt = MacroTools.@q $(lhs) ≂ $(rhs)
+        if has_model_parameter && has_observed
+            return Expr(
+                :if,
+                __generate_model_parameter_condition_expr(model_parameter_loop_vars),
+                Expr(:block, tilde_stmt),
+                Expr(
+                    :elseif,
+                    __generate_model_parameter_condition_expr(observed_loop_vars),
+                    Expr(:block, observe_stmt),
+                ),
+            )
+        elseif has_model_parameter
+            return Expr(
+                :if,
+                __generate_model_parameter_condition_expr(model_parameter_loop_vars),
+                Expr(:block, tilde_stmt),
+            )
+        elseif has_observed
+            return Expr(
+                :if,
+                __generate_model_parameter_condition_expr(observed_loop_vars),
+                Expr(:block, observe_stmt),
+            )
+        else
+            return nothing
+        end
+    else
+        # Deterministic `=` statement: keep the iterations that feed observations
+        # (transformed parameters); drop the generated-quantity ones.
+        if isempty(deterministic_loop_vars)
+            return nothing
+        end
+        return Expr(
+            :if,
+            __generate_model_parameter_condition_expr(deterministic_loop_vars),
+            Expr(:block, statement),
+        )
+    end
+end
+
 function __check_for_reserved_names(model_def::Expr)
     variable_names_and_numdims = JuliaBUGS.extract_variable_names_and_numdims(model_def)
     variable_names = keys(variable_names_and_numdims)
@@ -355,6 +424,7 @@ function _generate_lowered_model_def(
     g::JuliaBUGS.BUGSGraph,
     evaluation_env::NamedTuple;
     diagnostics::Vector{String}=String[],
+    generated_quantities::Set{<:VarName}=Set{VarName}(),
 )
     __check_for_reserved_names(model_def)
     stmt_to_stmt_id = _build_stmt_to_stmt_id(model_def)
@@ -419,7 +489,7 @@ function _generate_lowered_model_def(
     )
     induction_variable_values = _var_to_loop_vars(model_def, evaluation_env)
     var_types = __determine_var_types(
-        g, stmt_id_to_var, stmt_id_to_stmt, induction_variable_values
+        g, stmt_id_to_var, stmt_id_to_stmt, induction_variable_values, generated_quantities
     )
     lowered_model_def = _lower_model_def_to_represent_observe_stmts(
         reconstructed_model_def, stmt_to_stmt_id, var_types, evaluation_env
@@ -492,36 +562,45 @@ function _var_to_loop_vars(model_def, evaluation_env)
 end
 
 function __determine_var_types(
-    g::JuliaBUGS.BUGSGraph, stmt_id_to_var, stmt_id_to_stmt, induction_variable_values
+    g::JuliaBUGS.BUGSGraph,
+    stmt_id_to_var,
+    stmt_id_to_stmt,
+    induction_variable_values,
+    generated_quantities,
 )
-    # for each statement, have three list to collect the var of each type
-    var_types = [([], [], []) for _ in 1:length(stmt_id_to_stmt)]
+    # For each statement, collect the loop-variable values of each variable category:
+    # (observed, model_parameter, generated_quantity, deterministic).
+    var_types = [([], [], [], []) for _ in 1:length(stmt_id_to_stmt)]
     for stmt_id in keys(stmt_id_to_stmt)
         if !haskey(stmt_id_to_var, stmt_id)
             continue
         end
         vars = stmt_id_to_var[stmt_id]
         for var in vars
-            var_type = __variable_type(g, var)
+            var_type = __variable_type(g, var, generated_quantities)
             if var_type == :observed
                 push!(var_types[stmt_id][1], induction_variable_values[var])
             elseif var_type == :model_parameter
                 push!(var_types[stmt_id][2], induction_variable_values[var])
-            else
+            elseif var_type == :generated_quantity
                 push!(var_types[stmt_id][3], induction_variable_values[var])
+            else
+                push!(var_types[stmt_id][4], induction_variable_values[var])
             end
         end
     end
     return var_types
 end
 
-function __variable_type(g::JuliaBUGS.BUGSGraph, var)
-    if g[var].is_stochastic
-        if g[var].is_observed
-            return :observed
-        else
-            return :model_parameter
-        end
+function __variable_type(g::JuliaBUGS.BUGSGraph, var, generated_quantities)
+    if g[var].is_stochastic && g[var].is_observed
+        return :observed
+    elseif var in generated_quantities
+        # No observed descendants: stochastic ones are forward-sampled and deterministic
+        # ones are recomputed in post-processing, so neither belongs in the log density.
+        return :generated_quantity
+    elseif g[var].is_stochastic
+        return :model_parameter
     else
         return :deterministic
     end

--- a/JuliaBUGS/test/source_gen.jl
+++ b/JuliaBUGS/test/source_gen.jl
@@ -271,99 +271,223 @@ end
 end
 
 @testset "generated quantities in generated log-density function" begin
-    # A generated quantity is an unobserved node (stochastic or deterministic) that
-    # cannot reach any observation. It contributes nothing to the model log density,
-    # so the generated function must drop its `~`/`=` statement entirely. These tests
-    # check that the generated function matches graph evaluation (which already excludes
-    # GQ nodes from the log prior) and that GQ nodes are excluded from the parameter
-    # space, including when a GQ shares a loop with observed/parameter siblings.
+    # A generated quantity (GQ) is an unobserved node (stochastic or deterministic) that
+    # cannot reach any observation, so it contributes nothing to the model log density and
+    # the generated function must drop its `~`/`=` statement entirely. The helper below
+    # asserts the invariants the feature must uphold for each model:
+    #
+    #   I1  Mode-invariance: `model_parameters`, `generated_quantities`, and `dimension`
+    #       are identical between `UseGraph` and `UseGeneratedLogDensityFunction`. (This is
+    #       exactly what the conditioning/regeneration consistency bug used to violate.)
+    #   I2  Partition: a node is never both a model parameter and a generated quantity, and
+    #       `model_parameters ⊆ parameters ⊆ model_parameters ∪ generated_quantities`
+    #       (`parameters` additionally holds the stochastic generated quantities).
+    #   I3  Dimension reflects model parameters only: `dimension == length(getparams)` and
+    #       no generated quantity appears in the parameter vector.
+    #   I4  Generated ≡ graph: equal log density at matched parameter values, flattening
+    #       parameters in each model's own ordering (the generated model re-orders nodes to
+    #       loop-execution order).
+    #   I5  Generated quantities do not enter the log density: re-forward-sampling the GQ
+    #       (which changes only GQ values, leaving parameters and observations fixed) leaves
+    #       both `getparams` and the log density unchanged, in both modes.
     JuliaBUGS.@bugs_primitive Normal
 
-    # Compare graph vs generated log density at the same underlying values, flattening
-    # parameters in each model's own ordering (the generated model re-orders nodes to
-    # loop-execution order). Also returns the parameter dimension.
-    function gq_check(model_def, data)
-        model = compile(model_def, data)
+    fsgq = JuliaBUGS.Model.forward_sample_generated_quantities!!
+
+    # `n_params` is the number of (scalar) model parameters = the expected `dimension`;
+    # `n_gq` the number of generated-quantity nodes; `has_stochastic_gq` whether at least
+    # one GQ is stochastic (so re-sampling actually perturbs the environment).
+    function check_gq_invariants(model; n_params, n_gq, has_stochastic_gq)
         m_graph = JuliaBUGS.set_evaluation_mode(model, JuliaBUGS.UseGraph())
         m_gen = JuliaBUGS.set_evaluation_mode(
             model, JuliaBUGS.UseGeneratedLogDensityFunction()
         )
         @test !isnothing(m_gen.log_density_computation_function)
-        @test LogDensityProblems.dimension(m_graph) == LogDensityProblems.dimension(m_gen)
-        ok = true
-        for seed in 1:5
+
+        mp = Set(JuliaBUGS.model_parameters(m_graph))
+        gq = Set(JuliaBUGS.generated_quantities(m_graph))
+        allpar = Set(JuliaBUGS.parameters(m_graph))
+        dim = LogDensityProblems.dimension(m_graph)
+
+        # I1: classification and dimension do not depend on the evaluation mode.
+        @test Set(JuliaBUGS.model_parameters(m_gen)) == mp
+        @test Set(JuliaBUGS.generated_quantities(m_gen)) == gq
+        @test LogDensityProblems.dimension(m_gen) == dim
+
+        # Per-model anchors so a silent reclassification can't pass unnoticed.
+        @test length(mp) == n_params
+        @test length(gq) == n_gq
+        @test dim == n_params
+
+        # I2: model parameters and generated quantities partition the unobserved
+        # stochastic nodes; `parameters` is their union (it also lists stochastic GQ).
+        @test isempty(intersect(mp, gq))
+        @test issubset(mp, allpar)
+        @test issubset(allpar, union(mp, gq))
+
+        # I3: the parameter vector covers exactly the model parameters; no GQ leaks in.
+        @test length(JuliaBUGS.getparams(m_graph)) == dim
+        param_keys = Set(keys(JuliaBUGS.getparams(Dict, m_graph)))
+        @test param_keys == mp
+        @test isempty(intersect(param_keys, gq))
+
+        # I4: generated log density matches graph evaluation at matched values.
+        for seed in 1:8
             env, _ = Base.invokelatest(
                 JuliaBUGS.AbstractPPL.evaluate!!, Random.MersenneTwister(seed), model
             )
-            lp_graph = Base.invokelatest(
-                LogDensityProblems.logdensity, m_graph, JuliaBUGS.getparams(m_graph, env)
-            )
-            lp_gen = Base.invokelatest(
-                LogDensityProblems.logdensity, m_gen, JuliaBUGS.getparams(m_gen, env)
-            )
-            ok &= isapprox(lp_graph, lp_gen; atol=1e-10)
+            xg = JuliaBUGS.getparams(m_graph, env)
+            xgen = JuliaBUGS.getparams(m_gen, env)
+            @test length(xg) == length(xgen) == dim
+            lp_graph = Base.invokelatest(LogDensityProblems.logdensity, m_graph, xg)
+            lp_gen = Base.invokelatest(LogDensityProblems.logdensity, m_gen, xgen)
+            @test isapprox(lp_graph, lp_gen; atol=1e-10)
         end
-        @test ok
-        return LogDensityProblems.dimension(m_graph)
+
+        # I5: log density is invariant to the values of generated quantities. Two forward
+        # samples differ only in their GQ values; parameters and log density must not move.
+        base_env, _ = Base.invokelatest(
+            JuliaBUGS.AbstractPPL.evaluate!!, Random.MersenneTwister(99), model
+        )
+        # `fsgq` calls the compiled node functions directly, so invoke it in the latest
+        # world age (the helper is defined before these models are compiled).
+        env_a = Base.invokelatest(
+            fsgq, Random.MersenneTwister(1), model, deepcopy(base_env)
+        )
+        env_b = Base.invokelatest(
+            fsgq, Random.MersenneTwister(2), model, deepcopy(base_env)
+        )
+        @test JuliaBUGS.getparams(m_graph, env_a) == JuliaBUGS.getparams(m_graph, env_b)
+        if has_stochastic_gq
+            # Guard against a vacuous test: the GQ values really did change.
+            @test any(
+                vn ->
+                    JuliaBUGS.AbstractPPL.getvalue(env_a, vn) !=
+                    JuliaBUGS.AbstractPPL.getvalue(env_b, vn),
+                gq,
+            )
+        end
+        for m in (m_graph, m_gen)
+            m_a = BangBang.setproperty!!(m, :evaluation_env, env_a)
+            m_b = BangBang.setproperty!!(m, :evaluation_env, env_b)
+            lp_a = Base.invokelatest(
+                LogDensityProblems.logdensity, m_a, JuliaBUGS.getparams(m_a)
+            )
+            lp_b = Base.invokelatest(
+                LogDensityProblems.logdensity, m_b, JuliaBUGS.getparams(m_b)
+            )
+            @test isapprox(lp_a, lp_b; atol=1e-10)
+        end
+        return nothing
     end
 
     @testset "scalar GQ (stochastic + deterministic)" begin
         # z and pred are generated quantities; only mu is a parameter.
-        dim = gq_check((@bugs begin
-            mu ~ Normal(0, 1)
-            y ~ Normal(mu, 1)
-            z ~ Normal(mu, 1)
-            pred = mu + 1.0
-        end), (; y=0.5))
-        @test dim == 1
+        check_gq_invariants(
+            compile((@bugs begin
+                mu ~ Normal(0, 1)
+                y ~ Normal(mu, 1)
+                z ~ Normal(mu, 1)
+                pred = mu + 1.0
+            end), (; y=0.5));
+            n_params=1,
+            n_gq=2,
+            has_stochastic_gq=true,
+        )
     end
 
     @testset "chained GQ" begin
         # z and z2 form a GQ chain hanging off mu.
-        dim = gq_check((@bugs begin
-            mu ~ Normal(0, 1)
-            y ~ Normal(mu, 1)
-            z ~ Normal(mu, 1)
-            z2 ~ Normal(z, 1)
-        end), (; y=0.5))
-        @test dim == 1
+        check_gq_invariants(
+            compile((@bugs begin
+                mu ~ Normal(0, 1)
+                y ~ Normal(mu, 1)
+                z ~ Normal(mu, 1)
+                z2 ~ Normal(z, 1)
+            end), (; y=0.5));
+            n_params=1,
+            n_gq=2,
+            has_stochastic_gq=true,
+        )
     end
 
     @testset "all-GQ loop (entirely dropped)" begin
         # The whole g[1:3] loop is generated quantities and must drop out.
-        dim = gq_check((@bugs begin
-            mu ~ Normal(0, 1)
-            y ~ Normal(mu, 1)
-            for i in 1:3
-                g[i] ~ Normal(mu, 1)
-            end
-        end), (; y=0.5))
-        @test dim == 1
+        check_gq_invariants(
+            compile((@bugs begin
+                mu ~ Normal(0, 1)
+                y ~ Normal(mu, 1)
+                for i in 1:3
+                    g[i] ~ Normal(mu, 1)
+                end
+            end), (; y=0.5));
+            n_params=1,
+            n_gq=3,
+            has_stochastic_gq=true,
+        )
     end
 
     @testset "partial-observation loop (observed + GQ siblings)" begin
         # y[2], y[4] are missing with no observed descendant -> generated quantities.
-        dim = gq_check((@bugs begin
-            mu ~ Normal(0, 1)
-            for i in 1:4
-                y[i] ~ Normal(mu, 1)
-            end
-        end), (; y=[0.1, missing, 0.3, missing]))
-        @test dim == 1
+        check_gq_invariants(
+            compile((@bugs begin
+                mu ~ Normal(0, 1)
+                for i in 1:4
+                    y[i] ~ Normal(mu, 1)
+                end
+            end), (; y=[0.1, missing, 0.3, missing]));
+            n_params=1,
+            n_gq=2,
+            has_stochastic_gq=true,
+        )
     end
 
     @testset "mixed loops (observed + parameter in x, observed + GQ in z)" begin
         # x[1], x[3] are parameters; x[2], x[4] observed; z[1], z[3] observed
         # likelihoods; z[2], z[4] are generated quantities.
-        dim = gq_check(
-            (@bugs begin
-                for i in 1:4
-                    x[i] ~ Normal(0, 1)
-                    z[i] ~ Normal(x[i], 1)
-                end
-            end),
-            (; x=[missing, 1.0, missing, 2.0], z=[0.5, missing, 0.7, missing]),
+        check_gq_invariants(
+            compile(
+                (@bugs begin
+                    for i in 1:4
+                        x[i] ~ Normal(0, 1)
+                        z[i] ~ Normal(x[i], 1)
+                    end
+                end),
+                (; x=[missing, 1.0, missing, 2.0], z=[0.5, missing, 0.7, missing]),
+            );
+            n_params=2,
+            n_gq=2,
+            has_stochastic_gq=true,
         )
-        @test dim == 2
+    end
+
+    @testset "conditioning preserves classification (no-data model)" begin
+        # Compiling without data treats every node as a parameter (no-data shim). After
+        # conditioning x[1], x[3] the remaining x[2], y[1:3] stay parameters -- they must
+        # not be silently reclassified as generated quantities when the function is
+        # generated. This is the scenario the consistency bug broke.
+        model = compile((@bugs begin
+            for i in 1:3
+                x[i] ~ Normal(0, 1)
+            end
+            for i in 1:3
+                y[i] ~ Normal(x[i], 1)
+            end
+        end), (;))
+        model_cond = condition(model, Dict(@varname(x[1]) => 0.5, @varname(x[3]) => 1.5))
+        check_gq_invariants(model_cond; n_params=4, n_gq=0, has_stochastic_gq=false)
+    end
+
+    @testset "conditioning preserves a surviving generated quantity" begin
+        # z is a generated quantity of the original model; conditioning the only parameter
+        # mu must leave z classified as a generated quantity (preserved override) while the
+        # parameter space collapses to empty.
+        model = compile((@bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            z ~ Normal(mu, 1)
+        end), (; y=0.5))
+        model_cond = condition(model, Dict(@varname(mu) => 0.3))
+        check_gq_invariants(model_cond; n_params=0, n_gq=1, has_stochastic_gq=true)
     end
 end

--- a/JuliaBUGS/test/source_gen.jl
+++ b/JuliaBUGS/test/source_gen.jl
@@ -269,3 +269,101 @@ end
         @test isapprox(ld_graph, ld_gen; rtol=1e-10)
     end
 end
+
+@testset "generated quantities in generated log-density function" begin
+    # A generated quantity is an unobserved node (stochastic or deterministic) that
+    # cannot reach any observation. It contributes nothing to the model log density,
+    # so the generated function must drop its `~`/`=` statement entirely. These tests
+    # check that the generated function matches graph evaluation (which already excludes
+    # GQ nodes from the log prior) and that GQ nodes are excluded from the parameter
+    # space, including when a GQ shares a loop with observed/parameter siblings.
+    JuliaBUGS.@bugs_primitive Normal
+
+    # Compare graph vs generated log density at the same underlying values, flattening
+    # parameters in each model's own ordering (the generated model re-orders nodes to
+    # loop-execution order). Also returns the parameter dimension.
+    function gq_check(model_def, data)
+        model = compile(model_def, data)
+        m_graph = JuliaBUGS.set_evaluation_mode(model, JuliaBUGS.UseGraph())
+        m_gen = JuliaBUGS.set_evaluation_mode(
+            model, JuliaBUGS.UseGeneratedLogDensityFunction()
+        )
+        @test !isnothing(m_gen.log_density_computation_function)
+        @test LogDensityProblems.dimension(m_graph) == LogDensityProblems.dimension(m_gen)
+        ok = true
+        for seed in 1:5
+            env, _ = Base.invokelatest(
+                JuliaBUGS.AbstractPPL.evaluate!!, Random.MersenneTwister(seed), model
+            )
+            lp_graph = Base.invokelatest(
+                LogDensityProblems.logdensity, m_graph, JuliaBUGS.getparams(m_graph, env)
+            )
+            lp_gen = Base.invokelatest(
+                LogDensityProblems.logdensity, m_gen, JuliaBUGS.getparams(m_gen, env)
+            )
+            ok &= isapprox(lp_graph, lp_gen; atol=1e-10)
+        end
+        @test ok
+        return LogDensityProblems.dimension(m_graph)
+    end
+
+    @testset "scalar GQ (stochastic + deterministic)" begin
+        # z and pred are generated quantities; only mu is a parameter.
+        dim = gq_check((@bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            z ~ Normal(mu, 1)
+            pred = mu + 1.0
+        end), (; y=0.5))
+        @test dim == 1
+    end
+
+    @testset "chained GQ" begin
+        # z and z2 form a GQ chain hanging off mu.
+        dim = gq_check((@bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            z ~ Normal(mu, 1)
+            z2 ~ Normal(z, 1)
+        end), (; y=0.5))
+        @test dim == 1
+    end
+
+    @testset "all-GQ loop (entirely dropped)" begin
+        # The whole g[1:3] loop is generated quantities and must drop out.
+        dim = gq_check((@bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            for i in 1:3
+                g[i] ~ Normal(mu, 1)
+            end
+        end), (; y=0.5))
+        @test dim == 1
+    end
+
+    @testset "partial-observation loop (observed + GQ siblings)" begin
+        # y[2], y[4] are missing with no observed descendant -> generated quantities.
+        dim = gq_check((@bugs begin
+            mu ~ Normal(0, 1)
+            for i in 1:4
+                y[i] ~ Normal(mu, 1)
+            end
+        end), (; y=[0.1, missing, 0.3, missing]))
+        @test dim == 1
+    end
+
+    @testset "mixed loops (observed + parameter in x, observed + GQ in z)" begin
+        # x[1], x[3] are parameters; x[2], x[4] observed; z[1], z[3] observed
+        # likelihoods; z[2], z[4] are generated quantities.
+        dim = gq_check(
+            (@bugs begin
+                for i in 1:4
+                    x[i] ~ Normal(0, 1)
+                    z[i] ~ Normal(x[i], 1)
+                end
+            end),
+            (; x=[missing, 1.0, missing, 2.0], z=[0.5, missing, 0.7, missing]),
+        )
+        @test dim == 2
+    end
+end


### PR DESCRIPTION
## Summary

The compiled `UseGeneratedLogDensityFunction` mode previously bypassed to graph evaluation whenever a model contained generated quantities (unobserved nodes with no observed descendants). This makes the compiled path handle them natively by lowering the generated-quantity statements out of the log-density code, so the generated function computes exactly the marginal log density over the model parameters.

## What changed

- **`source_gen.jl`** — classify generated quantities as a distinct category and drop their statements from the lowered code (stochastic `~` and deterministic `=`), including generated-quantity iterations that share a loop with observed/parameter siblings. Driven by a new `generated_quantities` keyword on `_generate_lowered_model_def` (default empty, so dropping is opt-in at this layer).
- **`logdensityproblems.jl`** — remove the generated-quantity bypass; these models now use the real generated function.
- **`abstractppl.jl` / `bugsmodel.jl`** — when rebuilding `GraphEvaluationData` after generating the function, preserve the generated-quantity classification used for code generation via `gq_override`. Otherwise the 3-argument constructor re-derived it from the (possibly conditioned) graph and disagreed with the generated code, which broke conditioned models.

## Why the classification fix

Removing the bypass exposed a latent inconsistency: `set_evaluation_mode` and `_regenerate_log_density_function` generated the function from one generated-quantity set but stored a different one (recomputed from the conditioned graph). With the bypass gone the generated function is actually invoked, so the two must agree. Both now thread the same `gq_override` through.

## Tests

A new testset checks the invariants the feature must uphold, run over five generated-quantity models plus two conditioning scenarios (230 assertions):

- **Mode-invariance** — `model_parameters`, `generated_quantities`, and `dimension` are identical between `UseGraph` and `UseGeneratedLogDensityFunction`.
- **Partition** — a node is never both a parameter and a generated quantity; `model_parameters ⊆ parameters ⊆ model_parameters ∪ generated_quantities`.
- **Dimension reflects model parameters only** — `dimension == length(getparams)`, no generated quantity in the parameter vector.
- **Generated ≡ graph** at matched parameter values across random draws.
- **Generated quantities do not enter the log density** — re-forward-sampling the generated quantities leaves both `getparams` and the log density unchanged, in both modes.

The conditioning cases lock the fixed consistency bug: a no-data model whose conditioned parameters must not be reclassified, and a model whose generated quantity must survive conditioning of its only parameter.

Verified green locally: `compilation_source_gen`, `model_operations`, `log_density`, `compilation_model`.

https://claude.ai/code/session_01X2Ew8Yzg9A28nwarYkgAhe