### PR TITLE
Generated quantities under auto-marginalization

### DIFF
--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -577,7 +577,23 @@ function _marginalize_recursive(
     loop_vars = gd.loop_vars_vals[current_idx]
     rest_indices = @view(remaining_indices[2:end])
 
-    result = if !gd.is_stochastic_vals[current_idx]
+    result = if gd.variable_types[current_idx] == GeneratedQuantity
+        # Generated quantities have no observed descendants, so the whole generated-quantity
+        # block integrates/sums to one and factors out of the marginalized target p(θ, y).
+        # Skip it entirely: don't read the parameter vector (it has no slot there) and don't
+        # marginalize it. They are recovered later by forward sampling, not here.
+        _marginalize_recursive(
+            model,
+            env,
+            rest_indices,
+            parameter_values,
+            param_offsets,
+            var_lengths,
+            memo,
+            minimal_keys,
+        )
+
+    elseif !gd.is_stochastic_vals[current_idx]
         # Deterministic node: compute value and continue
         value = node_function(env, loop_vars)
         new_env = BangBang.setindex!!(env, value, current_vn)

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -274,6 +274,13 @@ ones are recomputed. Model parameters, observations, and transformed parameters 
 untouched. Nodes are visited in topological order, so chains of generated quantities are
 sampled with their parents already in place.
 
+If `model` is in `UseAutoMarginalization` mode its discrete latents were summed out of the
+log density and have no value in `evaluation_env`. A generated quantity may depend on such a
+latent (directly or indirectly), so before forward-sampling, the marginalized discrete
+latents are first recovered by sampling from their conditional posterior
+`p(z | θ, y)` (see [`_sample_discrete_latents!!`](@ref)). Generated quantities with no
+marginalized-discrete ancestor are unaffected by this step.
+
 This is the post-processing step that turns a posterior draw of the model parameters into a
 joint posterior(-predictive) draw that also includes the generated quantities.
 
@@ -285,6 +292,12 @@ function forward_sample_generated_quantities!!(
     model::BUGSModel,
     evaluation_env=smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols),
 )
+    # Under marginalization the discrete latents were summed out and carry no value, so
+    # recover them from their conditional posterior before any generated quantity that
+    # depends on them is forward-sampled.
+    if model.evaluation_mode isa UseAutoMarginalization
+        evaluation_env = _sample_discrete_latents!!(rng, model, evaluation_env)
+    end
     gd = model.graph_evaluation_data
     for (i, vn) in enumerate(gd.sorted_nodes)
         gd.variable_types[i] == GeneratedQuantity || continue
@@ -298,6 +311,118 @@ function forward_sample_generated_quantities!!(
         evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
     end
     return evaluation_env
+end
+
+"""
+    _sample_discrete_latents!!(rng, model, evaluation_env)
+
+Recover the marginalized discrete latents of an `UseAutoMarginalization` model by sampling
+them from their conditional posterior `p(z | θ, y)`, given an environment that already holds
+the continuous parameters and observations.
+
+The latents are drawn in the marginalization order: each discrete latent `z_i` is sampled
+from the weights `p(z_i = v | pa) · p(y, z_{>i} | z_i = v, …)`, where the second factor is
+the marginalized joint of everything downstream (computed by [`_marginalize_recursive`](@ref)
+with `z_i` fixed to `v` and the not-yet-sampled latents summed out). Normalizing over `v`
+gives exactly `p(z_i = v | z_{<i}, θ, y)`, so sampling the latents sequentially in
+topological order yields a draw from the joint posterior `p(z | θ, y)`. Continuous parameters
+are taken from `evaluation_env`; generated quantities are skipped (they are forward-sampled
+separately).
+"""
+function _sample_discrete_latents!!(
+    rng::Random.AbstractRNG, model::BUGSModel, evaluation_env
+)
+    mc = model.marginalization_cache
+    (mc === nothing || mc.n_discrete_finite == 0) && return evaluation_env
+    # Continuous parameters in the order/offsets expected by `_marginalize_recursive`.
+    param_values = getparams(model, evaluation_env)
+    return _backward_sample_recursive!!(
+        rng,
+        model,
+        evaluation_env,
+        mc.marginalization_order,
+        param_values,
+        mc.param_offsets,
+        mc.param_lengths,
+        mc.minimal_cache_keys,
+    )
+end
+
+function _backward_sample_recursive!!(
+    rng::Random.AbstractRNG,
+    model::BUGSModel,
+    env::NamedTuple,
+    remaining_indices::AbstractVector{Int},
+    param_values::AbstractVector,
+    param_offsets::Dict{<:VarName,Int},
+    var_lengths::Dict{<:VarName,Int},
+    minimal_keys::Dict{Int,Vector{Int}},
+)
+    isempty(remaining_indices) && return env
+
+    gd = model.graph_evaluation_data
+    mc = model.marginalization_cache
+
+    current_idx = remaining_indices[1]
+    current_vn = gd.sorted_nodes[current_idx]
+    rest_indices = @view(remaining_indices[2:end])
+    node_function = gd.node_function_vals[current_idx]
+    loop_vars = gd.loop_vars_vals[current_idx]
+
+    if gd.variable_types[current_idx] == GeneratedQuantity
+        # Generated quantities are forward-sampled separately; skip here.
+    elseif !gd.is_stochastic_vals[current_idx]
+        env = BangBang.setindex!!(env, node_function(env, loop_vars), current_vn)
+    elseif gd.is_observed_vals[current_idx]
+        # Observed value is already in the environment.
+    elseif mc.node_types[current_idx] == :discrete_finite
+        # Sample this latent from p(z_i = v | z_{<i}, θ, y), with z_{>i} marginalized.
+        dist = node_function(env, loop_vars)
+        possible_values = collect(_enumerate_discrete_values(dist))
+        log_weights = Vector{Float64}(undef, length(possible_values))
+        for (k, val) in enumerate(possible_values)
+            branch_env = BangBang.setindex!!(env, val, current_vn)
+            memo = Dict{Tuple{Int,Tuple},Tuple{Float64,Float64}}()
+            branch_prior, branch_lik = _marginalize_recursive(
+                model,
+                branch_env,
+                rest_indices,
+                param_values,
+                param_offsets,
+                var_lengths,
+                memo,
+                minimal_keys,
+            )
+            # The continuous-prior part of branch_prior is constant across `val` and
+            # cancels in the softmax below; the rest captures all `val`-dependent terms.
+            log_weights[k] = logpdf(dist, val) + branch_prior + branch_lik
+        end
+        weights = exp.(log_weights .- LogExpFunctions.logsumexp(log_weights))
+        sampled = possible_values[rand(rng, Distributions.Categorical(weights))]
+        env = BangBang.setindex!!(env, sampled, current_vn)
+    else
+        # Continuous (or discrete-infinite) parameter: set its value from the vector.
+        dist = node_function(env, loop_vars)
+        b_inv = Bijectors.inverse(Bijectors.bijector(dist))
+        len = var_lengths[current_vn]
+        start_idx = param_offsets[current_vn]
+        param_slice = view(param_values, start_idx:(start_idx + len - 1))
+        value, _ = Bijectors.with_logabsdet_jacobian(
+            b_inv, reconstruct(b_inv, dist, param_slice)
+        )
+        env = BangBang.setindex!!(env, value, current_vn)
+    end
+
+    return _backward_sample_recursive!!(
+        rng,
+        model,
+        env,
+        rest_indices,
+        param_values,
+        param_offsets,
+        var_lengths,
+        minimal_keys,
+    )
 end
 
 # ======================

--- a/JuliaBUGS/test/model/auto_marginalization.jl
+++ b/JuliaBUGS/test/model/auto_marginalization.jl
@@ -7,7 +7,8 @@ using JuliaBUGS.Model:
     UseAutoMarginalization,
     UseGraph,
     UseGeneratedLogDensityFunction,
-    evaluate_with_marginalization_values!!
+    evaluate_with_marginalization_values!!,
+    forward_sample_generated_quantities!!
 
 @testset "Auto-Marginalization" begin
     # HMM helper function for ground truth using forward algorithm
@@ -969,5 +970,68 @@ using JuliaBUGS.Model:
                 @test isapprox(lp, expected; atol=1e-6)
             end
         end
+    end
+
+    @testset "recover marginalized latents when forward-sampling GQ (case 3)" begin
+        # A generated quantity that depends on a marginalized discrete latent needs a value
+        # for that latent. `forward_sample_generated_quantities!!` recovers it by sampling
+        # from p(z | θ, y) before forward-sampling the GQ. Use a 2-state, 2-observation HMM
+        # with overlapping emissions so the posterior is spread across all states, and check
+        # the empirical distribution of the recovered (z[1], z[2]) against the analytic
+        # posterior and E[g] against the analytic mixture mean.
+        mu = [0.0, 2.0]
+        y_obs = [0.7, 1.3]
+        pivec = [0.5, 0.5]
+        trans = [0.7 0.3; 0.4 0.6]
+        W = [
+            pivec[i] *
+            pdf(Normal(mu[i], 1), y_obs[1]) *
+            trans[i, j] *
+            pdf(Normal(mu[j], 1), y_obs[2]) for i in 1:2, j in 1:2
+        ]
+        P = W ./ sum(W)               # analytic p(z[1], z[2] | y)
+        pz1 = vec(sum(P; dims=2))     # analytic p(z[1] | y)
+        Eg = sum(pz1 .* mu)           # analytic E[g] = E[mu[z[1]]]
+
+        hmm_case3 = @bugs begin
+            mu[1] = 0.0
+            mu[2] = 2.0
+            sigma = 1.0
+            trans[1, 1] = 0.7
+            trans[1, 2] = 0.3
+            trans[2, 1] = 0.4
+            trans[2, 2] = 0.6
+            pi[1] = 0.5
+            pi[2] = 0.5
+            z[1] ~ Categorical(pi[1:2])
+            for t in 2:T
+                p[t, 1] = trans[z[t - 1], 1]
+                p[t, 2] = trans[z[t - 1], 2]
+                z[t] ~ Categorical(p[t, :])
+            end
+            for t in 1:T
+                y[t] ~ Normal(mu[z[t]], sigma)
+            end
+            g ~ Normal(mu[z[1]], 1)      # case-3 GQ
+        end
+        model = set_evaluation_mode(
+            settrans(compile(hmm_case3, (T=2, y=y_obs)), true), UseAutoMarginalization()
+        )
+
+        N = 20000
+        counts = zeros(Int, 2, 2)
+        g_sum = 0.0
+        for s in 1:N
+            env = Base.invokelatest(
+                forward_sample_generated_quantities!!, StableRNG(s), model
+            )
+            z1 = Int(AbstractPPL.getvalue(env, @varname(z[1])))
+            z2 = Int(AbstractPPL.getvalue(env, @varname(z[2])))
+            counts[z1, z2] += 1
+            g_sum += AbstractPPL.getvalue(env, @varname(g))
+        end
+        P_emp = counts ./ N
+        @test maximum(abs.(P_emp .- P)) < 0.02
+        @test isapprox(g_sum / N, Eg; atol=0.05)
     end
 end

--- a/JuliaBUGS/test/model/auto_marginalization.jl
+++ b/JuliaBUGS/test/model/auto_marginalization.jl
@@ -6,6 +6,7 @@ using JuliaBUGS.Model:
     set_evaluation_mode,
     UseAutoMarginalization,
     UseGraph,
+    UseGeneratedLogDensityFunction,
     evaluate_with_marginalization_values!!
 
 @testset "Auto-Marginalization" begin
@@ -848,5 +849,125 @@ using JuliaBUGS.Model:
         # Both should give same results
         @test isapprox(val_rd, val_fd; atol=1e-10)
         @test isapprox(grad_rd, grad_fd; atol=1e-8)
+    end
+
+    @testset "generated quantities are excluded from the marginalized target" begin
+        # A generated quantity has no observed descendants, so its factor
+        # integrates/sums to one and the whole generated-quantity block factors out of
+        # p(θ, y). The marginalization must skip it: not read it from the parameter
+        # vector (it has no slot there) and not marginalize it.
+
+        @testset "no discrete latents: all three modes agree" begin
+            # Regression: marginalization used to throw `KeyError: z` on a continuous
+            # generated quantity, because the marginalization order included it but the
+            # parameter offsets (built over model parameters) did not.
+            model_def = @bugs begin
+                mu ~ Normal(0, 1)
+                y ~ Normal(mu, 1)
+                z ~ Normal(mu, 1)        # continuous generated quantity
+            end
+            model = settrans(compile(model_def, (; y=0.5)), true)
+            m_graph = set_evaluation_mode(model, UseGraph())
+            m_gen = set_evaluation_mode(model, UseGeneratedLogDensityFunction())
+            m_marg = set_evaluation_mode(model, UseAutoMarginalization())
+
+            @test LogDensityProblems.dimension(m_marg) ==
+                LogDensityProblems.dimension(m_graph)
+
+            # Compare at matched parameter values (flatten in each model's own order).
+            env, _ = Base.invokelatest(AbstractPPL.evaluate!!, StableRNG(1), model)
+            lp_graph = Base.invokelatest(
+                LogDensityProblems.logdensity, m_graph, getparams(m_graph, env)
+            )
+            lp_gen = Base.invokelatest(
+                LogDensityProblems.logdensity, m_gen, getparams(m_gen, env)
+            )
+            lp_marg = Base.invokelatest(
+                LogDensityProblems.logdensity, m_marg, getparams(m_marg, env)
+            )
+            @test isapprox(lp_graph, lp_marg; atol=1e-10)
+            @test isapprox(lp_gen, lp_marg; atol=1e-10)
+        end
+
+        @testset "discrete latent + GQ: marginalized log density unchanged" begin
+            # Fixed-parameter HMM (z[1], z[2] marginalized); reference via forward
+            # algorithm. Adding a generated quantity -- including one that depends on a
+            # marginalized latent (case 3) -- must not change the marginalized target.
+            expected = forward_algorithm_hmm(
+                [0.1, 4.9], 0.0, 5.0, 1.0, [0.5, 0.5], [0.7 0.3; 0.4 0.6]
+            )
+            data = (T=2, y=[0.1, 4.9])
+
+            hmm_base = @bugs begin
+                mu[1] = 0.0
+                mu[2] = 5.0
+                sigma = 1.0
+                trans[1, 1] = 0.7
+                trans[1, 2] = 0.3
+                trans[2, 1] = 0.4
+                trans[2, 2] = 0.6
+                pi[1] = 0.5
+                pi[2] = 0.5
+                z[1] ~ Categorical(pi[1:2])
+                for t in 2:T
+                    p[t, 1] = trans[z[t - 1], 1]
+                    p[t, 2] = trans[z[t - 1], 2]
+                    z[t] ~ Categorical(p[t, :])
+                end
+                for t in 1:T
+                    y[t] ~ Normal(mu[z[t]], sigma)
+                end
+            end
+            hmm_case2 = @bugs begin
+                mu[1] = 0.0
+                mu[2] = 5.0
+                sigma = 1.0
+                trans[1, 1] = 0.7
+                trans[1, 2] = 0.3
+                trans[2, 1] = 0.4
+                trans[2, 2] = 0.6
+                pi[1] = 0.5
+                pi[2] = 0.5
+                z[1] ~ Categorical(pi[1:2])
+                for t in 2:T
+                    p[t, 1] = trans[z[t - 1], 1]
+                    p[t, 2] = trans[z[t - 1], 2]
+                    z[t] ~ Categorical(p[t, :])
+                end
+                for t in 1:T
+                    y[t] ~ Normal(mu[z[t]], sigma)
+                end
+                g ~ Normal(0, 1)            # case-2 GQ (no marginalized-discrete ancestor)
+            end
+            hmm_case3 = @bugs begin
+                mu[1] = 0.0
+                mu[2] = 5.0
+                sigma = 1.0
+                trans[1, 1] = 0.7
+                trans[1, 2] = 0.3
+                trans[2, 1] = 0.4
+                trans[2, 2] = 0.6
+                pi[1] = 0.5
+                pi[2] = 0.5
+                z[1] ~ Categorical(pi[1:2])
+                for t in 2:T
+                    p[t, 1] = trans[z[t - 1], 1]
+                    p[t, 2] = trans[z[t - 1], 2]
+                    z[t] ~ Categorical(p[t, :])
+                end
+                for t in 1:T
+                    y[t] ~ Normal(mu[z[t]], sigma)
+                end
+                g ~ Normal(mu[z[1]], 1)     # case-3 GQ (depends on marginalized z[1])
+            end
+
+            for model_def in (hmm_base, hmm_case2, hmm_case3)
+                model = set_evaluation_mode(
+                    settrans(compile(model_def, data), true), UseAutoMarginalization()
+                )
+                lp = Base.invokelatest(LogDensityProblems.logdensity, model, Float64[])
+                @test isapprox(lp, expected; atol=1e-6)
+            end
+        end
     end
 end


### PR DESCRIPTION
## Summary

Makes `UseAutoMarginalization` work for models with generated quantities. Two pieces, one commit each:

1. **Exclude generated quantities from the marginalized log density.** Previously `logdensity` in marginalization mode threw `KeyError` on any continuous generated quantity.
2. **Recover marginalized discrete latents when forward-sampling generated quantities**, so a generated quantity that depends on a marginalized latent can be sampled correctly.

## Background — the three cases

For a model with continuous parameters θ (HMC-sampled), marginalized discrete latents z (discrete, *with* observed descendants), observations y, and generated quantities g (no observed descendants):

- **Marginalized discrete latents** — summed out of the HMC target, not in the chain. Not generated quantities.
- **Case 2: GQ with no marginalized-discrete ancestor** — forward-sample from θ directly (already worked).
- **Case 3: GQ depending on a marginalized latent z** — needs z, which must come from `p(z | θ, y)`.

## Commit 1 — log density

**Math.** The HMC target is
`p(θ, y) = Σ_z ∫_g p(θ, z, y, g) dg = Σ_z p(θ) p(z|·) p(y|·) · ∫_g p(g|·) dg = Σ_z p(θ) p(z|·) p(y|·)`.
The generated-quantity block integrates/sums to one (generated quantities are downward-closed: every descendant of a GQ is a GQ), so it factors out — even in case 3. Generated quantities therefore contribute nothing to the target and must be skipped.

**Root cause of the crash.** The marginalization order included every node, but the continuous parameter offsets are built only over the model parameters; a continuous GQ had no slot, so the recursion crashed reading it from the parameter vector.

**Fix.** `_marginalize_recursive` skips `GeneratedQuantity` nodes (no parameter-vector read, no marginalization).

**Tests.** (a) no discrete latents + continuous GQ: `UseGraph`, `UseGeneratedLogDensityFunction`, and `UseAutoMarginalization` agree (the former crash); (b) fixed-parameter HMM: adding a GQ — including a case-3 GQ — leaves the marginalized log density equal to the forward-algorithm reference.

## Commit 2 — forward-sampling (case 3)

**Math.** `p(θ, z, g | y) = p(θ|y) · p(z|θ,y) · p(g|θ,z)`. After HMC gives θ, recover z by sampling each latent in topological order from `p(z_i = v | z_{<i}, θ, y) ∝ p(z_i=v|pa) · p(y, z_{>i} | z_i=v, …)`, where the second factor is the marginalized joint of everything downstream (reuses `_marginalize_recursive` with z_i fixed). Then forward-sample g from the recovered z.

**Implementation.** `forward_sample_generated_quantities!!`, in marginalization mode, first calls `_sample_discrete_latents!!` to draw the latents from their conditional posterior, then forward-samples the generated quantities. Case-2 generated quantities (no marginalized-discrete ancestor) are unaffected; non-marginalized modes are unchanged.

**Test.** A 2-state, 2-observation HMM with overlapping emissions (balanced posterior). Over many draws the empirical distribution of the recovered `(z[1], z[2])` matches the analytic posterior and `E[g]` for `g ~ Normal(mu[z[1]], 1)` matches the analytic mixture mean.

## Verified locally

`log_density`, `inference_marginalization`, `inference_chains`, and `inference_hmc` all green.

## Follow-up (not in this PR)

End-to-end `gen_chains` for marginalized models has a separate, pre-existing gap: it reconstructs the environment with `evaluate!!(model, sample)`, but a marginalized sample is continuous-only while graph evaluation expects all model parameters. The forward-sampling primitive here is correct; wiring it through `gen_chains` for marginalized models is left as a follow-up.

https://claude.ai/code/session_01X2Ew8Yzg9A28nwarYkgAhe