### PR TITLE
Document generated quantities

### DIFF
--- a/JuliaBUGS/docs/make.jl
+++ b/JuliaBUGS/docs/make.jl
@@ -20,6 +20,7 @@ makedocs(;
             "Automatic Differentiation" => "inference/ad.md",
             "Evaluation Modes" => "inference/evaluation_modes.md",
             "Auto-Marginalization" => "inference/auto_marginalization.md",
+            "Generated Quantities" => "inference/generated_quantities.md",
             "Parallel & Distributed Sampling" => "inference/parallel.md",
         ],
         "API Reference" => [

--- a/JuliaBUGS/docs/src/inference/auto_marginalization.md
+++ b/JuliaBUGS/docs/src/inference/auto_marginalization.md
@@ -422,4 +422,8 @@ Enable auto-marginalization on a compiled model:
 
 Requires transformed space. Discrete variables must have finite support (Categorical, Bernoulli, etc.).
 
-See [Evaluation Modes](evaluation_modes.md) for more on `set_evaluation_mode`.
+See [Evaluation Modes](evaluation_modes.md) for more on `set_evaluation_mode`. A quantity
+derived from a marginalized discrete latent — for example a predicted observation or the
+latent state itself — is a [generated quantity](generated_quantities.md); it is excluded from
+the marginalized log density and recovered afterwards by sampling the latent from its
+conditional posterior.

--- a/JuliaBUGS/docs/src/inference/generated_quantities.md
+++ b/JuliaBUGS/docs/src/inference/generated_quantities.md
@@ -1,0 +1,108 @@
+# Generated Quantities
+
+A **generated quantity** is an unobserved node — stochastic or deterministic — that has
+**no observed descendants**: no directed path leads from it to any observation. Because it
+cannot influence the likelihood, it contributes nothing to the posterior over the model
+parameters. JuliaBUGS therefore keeps generated quantities *out of the inference target* and
+recovers them afterwards by forward sampling.
+
+Typical generated quantities are posterior-predictive draws, derived summaries, or latent
+states you want to report but not sample directly:
+
+```julia
+model_def = @bugs begin
+    mu ~ Normal(0, 1)
+    y ~ Normal(mu, 1)        # observed
+    y_pred ~ Normal(mu, 1)   # generated quantity (no observed descendant)
+    excess = y_pred - mu     # deterministic generated quantity
+end
+model = compile(model_def, (; y = 0.5))
+```
+
+Here `mu` is a model parameter, `y` is an observation, and `y_pred` and `excess` are
+generated quantities.
+
+## Classification
+
+Every node is assigned a [`VariableType`](@ref JuliaBUGS.VariableType): `Observation`, `ModelParameter`,
+`TransformedParameter`, or `GeneratedQuantity`. The partition that matters for inference is:
+
+- **Model parameters** — unobserved stochastic nodes that influence an observation. These are
+  what MCMC samples; they make up the parameter vector and the dimension.
+- **Generated quantities** — unobserved nodes with no observed descendants.
+
+The two sets are disjoint, and no model parameter or observation ever has a generated
+quantity as an ancestor.
+
+```julia
+JuliaBUGS.model_parameters(model)      # [mu]
+JuliaBUGS.generated_quantities(model)  # [y_pred, excess]
+JuliaBUGS.variable_type(model, @varname(y_pred))  # GeneratedQuantity
+```
+
+`parameters(model)` returns all unobserved stochastic nodes (model parameters together with
+the stochastic generated quantities); `model_parameters(model)` returns only the nodes that
+are actually sampled and counted in `LogDensityProblems.dimension`.
+
+## Log density
+
+Generated quantities are excluded from the log density in **every** [evaluation
+mode](evaluation_modes.md):
+
+```julia
+using LogDensityProblems
+LogDensityProblems.dimension(model)                  # 1 (mu only; y_pred/excess excluded)
+LogDensityProblems.logdensity(model, getparams(model))  # depends only on mu
+```
+
+This holds for `UseGraph`, `UseGeneratedLogDensityFunction` (the generated function drops the
+generated-quantity statements), and `UseAutoMarginalization` (the marginalization skips
+them). The log density is therefore identical across modes for the same parameter values.
+
+## Forward sampling
+
+After obtaining posterior draws of the model parameters, recover the generated quantities for
+each draw with [`forward_sample_generated_quantities!!`](@ref JuliaBUGS.Model.forward_sample_generated_quantities!!). It visits the generated
+quantities in topological order, drawing stochastic ones from their conditional distribution
+and recomputing deterministic ones, leaving model parameters and observations untouched:
+
+```julia
+using Random
+env, _ = AbstractPPL.evaluate!!(model, getparams(model))  # set parameters
+env = JuliaBUGS.Model.forward_sample_generated_quantities!!(Random.default_rng(), model, env)
+AbstractPPL.getvalue(env, @varname(y_pred))   # a posterior-predictive draw
+```
+
+When you build a chain with `JuliaBUGS.gen_chains`, this step is applied automatically, so the
+reported generated quantities are genuine posterior(-predictive) draws.
+
+### Under auto-marginalization
+
+If the model is in `UseAutoMarginalization` mode, its discrete latents were summed out of the
+log density and carry no value. A generated quantity may nonetheless depend on such a latent
+``z``. Before forward sampling, `forward_sample_generated_quantities!!` first recovers the
+latents from their conditional posterior ``p(z \mid \theta, y)``: each latent is drawn in
+topological order from the weights ``p(z_i = v \mid \mathrm{pa}) \cdot p(y, z_{>i} \mid z_i =
+v, \dots)``, where the second factor is the marginalized joint of everything downstream.
+Normalizing over ``v`` gives exactly ``p(z_i = v \mid z_{<i}, \theta, y)``, so the latents are
+drawn jointly from ``p(z \mid \theta, y)`` and the dependent generated quantity is then
+sampled from the recovered ``z``. Generated quantities with no marginalized-discrete ancestor
+are unaffected.
+
+## Models with no observations
+
+The classification depends on a model having at least one observation. If a model has **no**
+observations at all, JuliaBUGS does *not* treat every node as a generated quantity (which
+would leave nothing to sample); instead all unobserved stochastic nodes are kept as model
+parameters, so the model is sampled as the full prior. Add data (or `condition` on some
+variables) to obtain a non-trivial generated-quantity partition.
+
+## API
+
+```@docs
+JuliaBUGS.generated_quantities
+JuliaBUGS.model_parameters
+JuliaBUGS.variable_type
+JuliaBUGS.VariableType
+JuliaBUGS.Model.forward_sample_generated_quantities!!
+```

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -278,7 +278,7 @@ If `model` is in `UseAutoMarginalization` mode its discrete latents were summed 
 log density and have no value in `evaluation_env`. A generated quantity may depend on such a
 latent (directly or indirectly), so before forward-sampling, the marginalized discrete
 latents are first recovered by sampling from their conditional posterior
-`p(z | θ, y)` (see [`_sample_discrete_latents!!`](@ref)). Generated quantities with no
+`p(z | θ, y)` (see `_sample_discrete_latents!!`). Generated quantities with no
 marginalized-discrete ancestor are unaffected by this step.
 
 This is the post-processing step that turns a posterior draw of the model parameters into a


### PR DESCRIPTION
## Summary

Adds user-facing documentation for the generated-quantities feature, which currently has no docs.

- **New page** `inference/generated_quantities.md` (under "Inference"):
  - what a generated quantity is and how it is classified (unobserved node with no observed descendants);
  - that it is excluded from the log density in all three evaluation modes;
  - how to forward-sample with `forward_sample_generated_quantities!!`, including recovery of marginalized discrete latents (`p(z | θ, y)`) under auto-marginalization;
  - the no-observation behavior (everything stays a model parameter);
  - an API section documenting `generated_quantities`, `model_parameters`, `variable_type`, `VariableType`, and `forward_sample_generated_quantities!!`.
- Cross-reference from `inference/auto_marginalization.md`.
- Demote an internal `@ref` in the `forward_sample_generated_quantities!!` docstring to plain code so the rendered docstring has no dangling cross-reference.

## Verification

`makedocs` builds locally with exit 0 and no warnings on the new page (the only build warnings are pre-existing cross-references in `api/functions.md`).

https://claude.ai/code/session_01X2Ew8Yzg9A28nwarYkgAhe