### PR TITLE
Variable-type classification and generated quantities

### DIFF
--- a/JuliaBUGS/History.md
+++ b/JuliaBUGS/History.md
@@ -1,5 +1,19 @@
 # JuliaBUGS Changelog
 
+## 0.15.0
+
+### Highlights
+
+- **Generated quantities (#501).** Every node now carries an explicit `VariableType`: `Observation`, `ModelParameter`, `TransformedParameter`, or `GeneratedQuantity`. A *generated quantity* is an unobserved node (stochastic or deterministic) with no observed descendants, so it lies outside the log-density target. Generated quantities are excluded from the log density in all three evaluation modes (`UseGraph`, `UseGeneratedLogDensityFunction`, `UseAutoMarginalization`) and recovered after sampling by forward simulation instead of being sampled by MCMC. Under auto-marginalization, a generated quantity that depends on a marginalized discrete latent first recovers that latent from its conditional posterior `p(z | θ, y)`. `gen_chains` applies this automatically, so reported generated quantities are genuine posterior(-predictive) draws.
+
+- **New API:** `model_parameters(model)`, `generated_quantities(model)`, `variable_type(model, vn)`, the `VariableType` enum and its instances, and `Model.forward_sample_generated_quantities!!`.
+
+### Breaking Changes
+
+- Unobserved stochastic nodes with **no observed descendants** (e.g. posterior-predictive draws, or priors unused by any likelihood) are now generated quantities: excluded from `model_parameters`, the parameter vector, and `LogDensityProblems.dimension`, and forward-sampled in post-processing instead of sampled by MCMC/Gibbs. The joint distribution is unchanged.
+- `parameters(model)` (all unobserved stochastic nodes) and `model_parameters(model)` (the MCMC target) can now differ, and `dimension` follows `model_parameters`. Use `LogDensityProblems.dimension(model)` (or `length(model_parameters(model))`) where you previously relied on `length(parameters(model))` as the parameter-vector length.
+- `Gibbs` sampler maps that reference a reclassified variable now error, since it is no longer in `model_parameters`.
+
 ## 0.14.1
 
 ### Highlights

--- a/JuliaBUGS/History.md
+++ b/JuliaBUGS/History.md
@@ -6,7 +6,7 @@
 
 - **Generated quantities (#501).** Every node now carries an explicit `VariableType`: `Observation`, `ModelParameter`, `TransformedParameter`, or `GeneratedQuantity`. A *generated quantity* is an unobserved node (stochastic or deterministic) with no observed descendants, so it lies outside the log-density target. Generated quantities are excluded from the log density in all three evaluation modes (`UseGraph`, `UseGeneratedLogDensityFunction`, `UseAutoMarginalization`) and recovered after sampling by forward simulation instead of being sampled by MCMC. Under auto-marginalization, a generated quantity that depends on a marginalized discrete latent first recovers that latent from its conditional posterior `p(z | θ, y)`. `gen_chains` applies this automatically, so reported generated quantities are genuine posterior(-predictive) draws.
 
-- **New API:** `model_parameters(model)`, `generated_quantities(model)`, `variable_type(model, vn)`, the `VariableType` enum and its instances, and `Model.forward_sample_generated_quantities!!`.
+- **New functions**, exported from the `JuliaBUGS.Model` submodule (like the existing `parameters`), so reachable as `JuliaBUGS.model_parameters` rather than via `using JuliaBUGS`: `model_parameters`, `generated_quantities`, `variable_type`, and the `VariableType` enum with its instances. `forward_sample_generated_quantities!!` is unexported, available as `JuliaBUGS.Model.forward_sample_generated_quantities!!`.
 
 ### Breaking Changes
 

--- a/JuliaBUGS/Project.toml
+++ b/JuliaBUGS/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaBUGS"
 uuid = "ba9fb4c0-828e-4473-b6a1-cd2560fee5bf"
-version = "0.14.1"
+version = "0.15.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/JuliaBUGS/docs/make.jl
+++ b/JuliaBUGS/docs/make.jl
@@ -20,6 +20,7 @@ makedocs(;
             "Automatic Differentiation" => "inference/ad.md",
             "Evaluation Modes" => "inference/evaluation_modes.md",
             "Auto-Marginalization" => "inference/auto_marginalization.md",
+            "Generated Quantities" => "inference/generated_quantities.md",
             "Parallel & Distributed Sampling" => "inference/parallel.md",
         ],
         "API Reference" => [

--- a/JuliaBUGS/docs/src/inference/auto_marginalization.md
+++ b/JuliaBUGS/docs/src/inference/auto_marginalization.md
@@ -422,4 +422,8 @@ Enable auto-marginalization on a compiled model:
 
 Requires transformed space. Discrete variables must have finite support (Categorical, Bernoulli, etc.).
 
-See [Evaluation Modes](evaluation_modes.md) for more on `set_evaluation_mode`.
+See [Evaluation Modes](evaluation_modes.md) for more on `set_evaluation_mode`. A quantity
+derived from a marginalized discrete latent — for example a predicted observation or the
+latent state itself — is a [generated quantity](generated_quantities.md); it is excluded from
+the marginalized log density and recovered afterwards by sampling the latent from its
+conditional posterior.

--- a/JuliaBUGS/docs/src/inference/generated_quantities.md
+++ b/JuliaBUGS/docs/src/inference/generated_quantities.md
@@ -1,10 +1,11 @@
 # Generated Quantities
 
-A **generated quantity** is an unobserved node — stochastic or deterministic — that has
-**no observed descendants**: no directed path leads from it to any observation. Because it
-cannot influence the likelihood, it contributes nothing to the posterior over the model
-parameters. JuliaBUGS therefore keeps generated quantities *out of the inference target* and
-recovers them afterwards by forward sampling.
+A **generated quantity** is an unobserved node — stochastic or deterministic — that is
+outside the log-density target dependency closure. In a model with observations, this usually
+means the node has **no observed descendants**: no directed path leads from it to any
+observation. Because it cannot influence the target density over the model parameters,
+JuliaBUGS keeps generated quantities *out of the inference target* and recovers them
+afterwards by forward sampling.
 
 Typical generated quantities are posterior-predictive draws, derived summaries, or latent
 states you want to report but not sample directly:
@@ -27,9 +28,10 @@ generated quantities.
 Every node is assigned a [`VariableType`](@ref JuliaBUGS.VariableType): `Observation`, `ModelParameter`,
 `TransformedParameter`, or `GeneratedQuantity`. The partition that matters for inference is:
 
-- **Model parameters** — unobserved stochastic nodes that influence an observation. These are
-  what MCMC samples; they make up the parameter vector and the dimension.
-- **Generated quantities** — unobserved nodes with no observed descendants.
+- **Model parameters** — unobserved stochastic nodes in the target. These are what MCMC
+  samples; they make up the parameter vector and the dimension.
+- **Transformed parameters** — deterministic nodes needed to evaluate the target density.
+- **Generated quantities** — unobserved nodes outside the target dependency closure.
 
 The two sets are disjoint, and no model parameter or observation ever has a generated
 quantity as an ancestor.
@@ -91,11 +93,28 @@ are unaffected.
 
 ## Models with no observations
 
-The classification depends on a model having at least one observation. If a model has **no**
-observations at all, JuliaBUGS does *not* treat every node as a generated quantity (which
-would leave nothing to sample); instead all unobserved stochastic nodes are kept as model
-parameters, so the model is sampled as the full prior. Add data (or `condition` on some
-variables) to obtain a non-trivial generated-quantity partition.
+If a model has **no** observations at all, JuliaBUGS does *not* treat every node as a
+generated quantity (which would leave nothing to sample). Instead all unobserved stochastic
+nodes are kept as model parameters, so the model is sampled as the full prior. Deterministic
+ancestors of those stochastic parameters are transformed parameters and are recomputed during
+log-density evaluation. Terminal deterministic nodes that do not feed any stochastic factor
+can still be generated quantities.
+
+For example, in this prior-only model `h` is **not** a generated quantity because the prior
+factor for `y` depends on it:
+
+```julia
+model_def = @bugs begin
+    x ~ Normal(0, 1)
+    h = x + 1
+    y ~ Normal(h, 1)
+end
+model = compile(model_def, (;))
+JuliaBUGS.variable_type(model, @varname(h))  # TransformedParameter
+```
+
+Add data (or `condition` on some variables) to obtain the usual observed-data
+generated-quantity partition.
 
 ## API
 

--- a/JuliaBUGS/docs/src/inference/generated_quantities.md
+++ b/JuliaBUGS/docs/src/inference/generated_quantities.md
@@ -1,0 +1,108 @@
+# Generated Quantities
+
+A **generated quantity** is an unobserved node — stochastic or deterministic — that has
+**no observed descendants**: no directed path leads from it to any observation. Because it
+cannot influence the likelihood, it contributes nothing to the posterior over the model
+parameters. JuliaBUGS therefore keeps generated quantities *out of the inference target* and
+recovers them afterwards by forward sampling.
+
+Typical generated quantities are posterior-predictive draws, derived summaries, or latent
+states you want to report but not sample directly:
+
+```julia
+model_def = @bugs begin
+    mu ~ Normal(0, 1)
+    y ~ Normal(mu, 1)        # observed
+    y_pred ~ Normal(mu, 1)   # generated quantity (no observed descendant)
+    excess = y_pred - mu     # deterministic generated quantity
+end
+model = compile(model_def, (; y = 0.5))
+```
+
+Here `mu` is a model parameter, `y` is an observation, and `y_pred` and `excess` are
+generated quantities.
+
+## Classification
+
+Every node is assigned a [`VariableType`](@ref JuliaBUGS.VariableType): `Observation`, `ModelParameter`,
+`TransformedParameter`, or `GeneratedQuantity`. The partition that matters for inference is:
+
+- **Model parameters** — unobserved stochastic nodes that influence an observation. These are
+  what MCMC samples; they make up the parameter vector and the dimension.
+- **Generated quantities** — unobserved nodes with no observed descendants.
+
+The two sets are disjoint, and no model parameter or observation ever has a generated
+quantity as an ancestor.
+
+```julia
+JuliaBUGS.model_parameters(model)      # [mu]
+JuliaBUGS.generated_quantities(model)  # [y_pred, excess]
+JuliaBUGS.variable_type(model, @varname(y_pred))  # GeneratedQuantity
+```
+
+`parameters(model)` returns all unobserved stochastic nodes (model parameters together with
+the stochastic generated quantities); `model_parameters(model)` returns only the nodes that
+are actually sampled and counted in `LogDensityProblems.dimension`.
+
+## Log density
+
+Generated quantities are excluded from the log density in **every** [evaluation
+mode](evaluation_modes.md):
+
+```julia
+using LogDensityProblems
+LogDensityProblems.dimension(model)                  # 1 (mu only; y_pred/excess excluded)
+LogDensityProblems.logdensity(model, getparams(model))  # depends only on mu
+```
+
+This holds for `UseGraph`, `UseGeneratedLogDensityFunction` (the generated function drops the
+generated-quantity statements), and `UseAutoMarginalization` (the marginalization skips
+them). The log density is therefore identical across modes for the same parameter values.
+
+## Forward sampling
+
+After obtaining posterior draws of the model parameters, recover the generated quantities for
+each draw with [`forward_sample_generated_quantities!!`](@ref JuliaBUGS.Model.forward_sample_generated_quantities!!). It visits the generated
+quantities in topological order, drawing stochastic ones from their conditional distribution
+and recomputing deterministic ones, leaving model parameters and observations untouched:
+
+```julia
+using Random
+env, _ = AbstractPPL.evaluate!!(model, getparams(model))  # set parameters
+env = JuliaBUGS.Model.forward_sample_generated_quantities!!(Random.default_rng(), model, env)
+AbstractPPL.getvalue(env, @varname(y_pred))   # a posterior-predictive draw
+```
+
+When you build a chain with `JuliaBUGS.gen_chains`, this step is applied automatically, so the
+reported generated quantities are genuine posterior(-predictive) draws.
+
+### Under auto-marginalization
+
+If the model is in `UseAutoMarginalization` mode, its discrete latents were summed out of the
+log density and carry no value. A generated quantity may nonetheless depend on such a latent
+``z``. Before forward sampling, `forward_sample_generated_quantities!!` first recovers the
+latents from their conditional posterior ``p(z \mid \theta, y)``: each latent is drawn in
+topological order from the weights ``p(z_i = v \mid \mathrm{pa}) \cdot p(y, z_{>i} \mid z_i =
+v, \dots)``, where the second factor is the marginalized joint of everything downstream.
+Normalizing over ``v`` gives exactly ``p(z_i = v \mid z_{<i}, \theta, y)``, so the latents are
+drawn jointly from ``p(z \mid \theta, y)`` and the dependent generated quantity is then
+sampled from the recovered ``z``. Generated quantities with no marginalized-discrete ancestor
+are unaffected.
+
+## Models with no observations
+
+The classification depends on a model having at least one observation. If a model has **no**
+observations at all, JuliaBUGS does *not* treat every node as a generated quantity (which
+would leave nothing to sample); instead all unobserved stochastic nodes are kept as model
+parameters, so the model is sampled as the full prior. Add data (or `condition` on some
+variables) to obtain a non-trivial generated-quantity partition.
+
+## API
+
+```@docs
+JuliaBUGS.generated_quantities
+JuliaBUGS.model_parameters
+JuliaBUGS.variable_type
+JuliaBUGS.VariableType
+JuliaBUGS.Model.forward_sample_generated_quantities!!
+```

--- a/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
@@ -8,7 +8,7 @@ using JuliaBUGS:
     find_generated_quantities_variables,
     evaluate!!,
     getparams
-using JuliaBUGS.Model: UseAutoMarginalization
+using JuliaBUGS.Model: UseAutoMarginalization, model_parameters
 using JuliaBUGS.AbstractPPL
 using JuliaBUGS.Accessors
 using MCMCChains: Chains
@@ -132,17 +132,8 @@ function JuliaBUGS.gen_chains(
     kwargs...,
 )
     gd = model.graph_evaluation_data
-    # Filter parameters based on evaluation mode - only include continuous parameters
-    # when auto-marginalization is active (discrete parameters are marginalized out)
-    param_vars = if model.evaluation_mode isa UseAutoMarginalization
-        mc = model.marginalization_cache
-        filter(gd.sorted_parameters) do vn
-            idx = findfirst(==(vn), gd.sorted_nodes)
-            idx !== nothing && mc.node_types[idx] == :continuous
-        end
-    else
-        gd.sorted_parameters
-    end
+    # Filter parameters based on evaluation mode and MCMC partition.
+    param_vars = model_parameters(model)
 
     # Find and order generated quantities
     # Exclude parameters to avoid double counting forward-sampled variables

--- a/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
@@ -134,7 +134,8 @@ function JuliaBUGS.gen_chains(
     kwargs...,
 )
     gd = model.graph_evaluation_data
-    # Filter parameters based on evaluation mode and MCMC partition.
+    # Report model parameters. In auto-marginalization, continuous parameters come from
+    # the sample row and finite discrete latents are recovered below from p(z | theta, y).
     param_vars = model_parameters(model)
 
     # Generated quantities (no observed descendants) are reported in topological order;
@@ -155,8 +156,7 @@ function JuliaBUGS.gen_chains(
         # draws rather than the stale environment values left by `evaluate!!`.
         evaluation_env = forward_sample_generated_quantities!!(rng, model, evaluation_env)
 
-        # Get parameter values from the evaluation environment
-        # (they were just set by evaluate!!, so they match samples[i])
+        # Get parameter values from the reconstructed evaluation environment.
         push!(
             param_vals,
             [AbstractPPL.getvalue(evaluation_env, param_var) for param_var in param_vars],

--- a/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
@@ -8,10 +8,11 @@ using JuliaBUGS:
     find_generated_quantities_variables,
     evaluate!!,
     getparams
-using JuliaBUGS.Model: UseAutoMarginalization, model_parameters
+using JuliaBUGS.Model: model_parameters, forward_sample_generated_quantities!!
 using JuliaBUGS.AbstractPPL
 using JuliaBUGS.Accessors
 using MCMCChains: Chains
+using Random: default_rng
 
 function JuliaBUGS.gen_chains(
     model::AbstractMCMC.LogDensityModel{<:BUGSModel},
@@ -127,6 +128,7 @@ function JuliaBUGS.gen_chains(
     samples,
     stats_names,
     stats_values;
+    rng=default_rng(),
     discard_initial=0,
     thinning=1,
     kwargs...,
@@ -135,8 +137,8 @@ function JuliaBUGS.gen_chains(
     # Filter parameters based on evaluation mode and MCMC partition.
     param_vars = model_parameters(model)
 
-    # Find and order generated quantities
-    # Exclude parameters to avoid double counting forward-sampled variables
+    # Generated quantities (no observed descendants) are reported in topological order;
+    # they are disjoint from the model parameters by construction.
     generated_vars = find_generated_quantities_variables(model.g)
     param_set = Set(param_vars)
     generated_vars = [v for v in gd.sorted_nodes if v in generated_vars && v ∉ param_set]
@@ -147,6 +149,11 @@ function JuliaBUGS.gen_chains(
     for i in axes(samples)[1]
         # Set parameters and evaluate the model
         evaluation_env = first(evaluate!!(model, samples[i]))
+
+        # Forward-sample the stochastic generated quantities (and recompute deterministic
+        # ones) for this draw, so the reported values are genuine posterior-predictive
+        # draws rather than the stale environment values left by `evaluate!!`.
+        evaluation_env = forward_sample_generated_quantities!!(rng, model, evaluation_env)
 
         # Get parameter values from the evaluation environment
         # (they were just set by evaluate!!, so they match samples[i])

--- a/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
@@ -2,12 +2,7 @@ module JuliaBUGSMCMCChainsExt
 
 using AbstractMCMC
 using JuliaBUGS
-using JuliaBUGS:
-    BUGSModel,
-    BUGSModelWithGradient,
-    find_generated_quantities_variables,
-    evaluate!!,
-    getparams
+using JuliaBUGS: BUGSModel, BUGSModelWithGradient, evaluate!!, getparams
 using JuliaBUGS.Model: model_parameters, forward_sample_generated_quantities!!
 using JuliaBUGS.AbstractPPL
 using JuliaBUGS.Accessors
@@ -133,16 +128,13 @@ function JuliaBUGS.gen_chains(
     thinning=1,
     kwargs...,
 )
-    gd = model.graph_evaluation_data
     # Report model parameters. In auto-marginalization, continuous parameters come from
     # the sample row and finite discrete latents are recovered below from p(z | theta, y).
     param_vars = model_parameters(model)
 
     # Generated quantities (no observed descendants) are reported in topological order;
     # they are disjoint from the model parameters by construction.
-    generated_vars = find_generated_quantities_variables(model.g)
-    param_set = Set(param_vars)
-    generated_vars = [v for v in gd.sorted_nodes if v in generated_vars && v ∉ param_set]
+    generated_vars = JuliaBUGS.Model.generated_quantities(model)
 
     # Evaluate model for each sample to get parameter values and generated quantities
     param_vals = []

--- a/JuliaBUGS/src/compiler_pass.jl
+++ b/JuliaBUGS/src/compiler_pass.jl
@@ -839,7 +839,7 @@ function analyze_statement(pass::AddVertices, expr::Expr, loop_vars::NamedTuple)
     args, node_function_expr, node_function = pass.f_dict[expr]
 
     vn = if lhs isa Symbol
-        AbstractPPL.VarName{lhs}(AbstractPPL.Iden())
+        AbstractPPL.VarName{lhs}()
     else
         v, indices... = lhs
         AbstractPPL.VarName{v}(AbstractPPL.Index((indices...,), (;)))

--- a/JuliaBUGS/src/gibbs.jl
+++ b/JuliaBUGS/src/gibbs.jl
@@ -109,7 +109,7 @@ gibbs = Gibbs(model, sampler_map)
 function Gibbs(model::BUGSModel, sampler_map::OrderedDict)
     verify_sampler_map(model, sampler_map)
     # Expand variable groups once to avoid repeated computation
-    model_parameters = model.graph_evaluation_data.sorted_parameters
+    model_parameters = model.graph_evaluation_data.model_parameters
     expanded_sampler_map = OrderedDict()
     for (variable_group, sampler) in sampler_map
         variable_group_vec =
@@ -155,7 +155,7 @@ parameters and using the OrderedDict constructor instead.
 function Gibbs(model::BUGSModel, s::AbstractMCMC.AbstractSampler)
     # Use the sampler as-is for all parameters
     sampler_map = OrderedDict([
-        v => s for v in model.graph_evaluation_data.sorted_parameters
+        v => s for v in model.graph_evaluation_data.model_parameters
     ])
     return Gibbs(model, sampler_map)
 end
@@ -291,7 +291,7 @@ function verify_sampler_map(model::BUGSModel, sampler_map::OrderedDict)
     end
 
     # Get model parameters
-    model_parameters = model.graph_evaluation_data.sorted_parameters
+    model_parameters = model.graph_evaluation_data.model_parameters
 
     # Track which model parameters are covered
     covered_parameters = Set{VarName}()
@@ -364,7 +364,7 @@ function AbstractMCMC.step(
     verify_sampler_map(model, sampler.sampler_map)
 
     cached_conditioned_models = OrderedDict()
-    model_parameters = model.graph_evaluation_data.sorted_parameters
+    model_parameters = model.graph_evaluation_data.model_parameters
 
     for variables_to_update in keys(sampler.sampler_map)
         # Variables to condition on are all parameters except those we're updating

--- a/JuliaBUGS/src/model/Model.jl
+++ b/JuliaBUGS/src/model/Model.jl
@@ -9,7 +9,7 @@ using Bijectors
 using Distributions
 using Graphs
 using LinearAlgebra
-using JuliaBUGS: JuliaBUGS, BUGSGraph
+using JuliaBUGS: JuliaBUGS, BUGSGraph, find_generated_quantities_variables
 using JuliaBUGS.BUGSPrimitives
 using LogExpFunctions
 using MetaGraphsNext
@@ -27,6 +27,10 @@ include("to_distribution.jl")
 # Public user-facing API
 export parameters, variables, initialize!, getparams, settrans, to_distribution
 export set_evaluation_mode, set_observed_values!
+export model_parameters, generated_quantities, variable_type
+
+# Variable classification
+export VariableType, Observation, ModelParameter, TransformedParameter, GeneratedQuantity
 
 # Evaluation mode types
 export UseGraph, UseGeneratedLogDensityFunction, UseAutoMarginalization

--- a/JuliaBUGS/src/model/abstractmcmc.jl
+++ b/JuliaBUGS/src/model/abstractmcmc.jl
@@ -10,17 +10,8 @@ function AbstractMCMC.ParamsWithStats(
     extras::Bool=false,
 )
     bugs_model = model.logdensity
-    gd = bugs_model.graph_evaluation_data
 
-    param_vars = if bugs_model.evaluation_mode isa UseAutoMarginalization
-        mc = bugs_model.marginalization_cache
-        filter(gd.sorted_parameters) do vn
-            idx = findfirst(==(vn), gd.sorted_nodes)
-            idx !== nothing && mc.node_types[idx] == :continuous
-        end
-    else
-        gd.sorted_parameters
-    end
+    param_vars = model_parameters(bugs_model)
 
     p = if params
         d = OrderedDict{String,Any}()

--- a/JuliaBUGS/src/model/abstractmcmc.jl
+++ b/JuliaBUGS/src/model/abstractmcmc.jl
@@ -11,12 +11,17 @@ function AbstractMCMC.ParamsWithStats(
 )
     bugs_model = model.logdensity
 
-    param_vars = model_parameters(bugs_model)
+    transition_env = merge(bugs_model.evaluation_env, transition)
+    param_vars = if bugs_model.evaluation_mode isa UseAutoMarginalization
+        bugs_model.marginalization_cache.continuous_model_parameters
+    else
+        model_parameters(bugs_model)
+    end
 
     p = if params
         d = OrderedDict{String,Any}()
         for vn in param_vars
-            value = AbstractPPL.getvalue(transition, vn)
+            value = AbstractPPL.getvalue(transition_env, vn)
             d[string(vn)] = value
         end
         [k => v for (k, v) in d]
@@ -25,10 +30,16 @@ function AbstractMCMC.ParamsWithStats(
     end
 
     s = if stats
-        model_with_env = BangBang.setproperty!!(bugs_model, :evaluation_env, transition)
-        _, log_densities = evaluate_with_env!!(
-            model_with_env; transformed=bugs_model.transformed
-        )
+        log_densities = if bugs_model.evaluation_mode isa UseAutoMarginalization
+            _, lds = evaluate_with_marginalization_values!!(
+                bugs_model, getparams(bugs_model, transition_env)
+            )
+            lds
+        else
+            model_with_env = BangBang.setproperty!!(bugs_model, :evaluation_env, transition_env)
+            _, lds = evaluate_with_env!!(model_with_env; transformed=bugs_model.transformed)
+            lds
+        end
         (lp=log_densities.tempered_logjoint,)
     else
         NamedTuple()

--- a/JuliaBUGS/src/model/abstractppl.jl
+++ b/JuliaBUGS/src/model/abstractppl.jl
@@ -544,9 +544,9 @@ function _create_modified_model(
 )
     # Create new graph evaluation data preserving the original GQ classification
     # We must explicitly keep the original `generated_quantities` to avoid them being reclassified.
-    original_gq = Set(generated_quantities(
-        isnothing(model.base_model) ? model : model.base_model
-    ))
+    original_gq = Set(
+        generated_quantities(isnothing(model.base_model) ? model : model.base_model)
+    )
     new_graph_evaluation_data = GraphEvaluationData(new_graph; gq_override=original_gq)
     new_parameters = new_graph_evaluation_data.model_parameters
 
@@ -591,7 +591,10 @@ function _regenerate_log_density_function(
     graph_evaluation_data::GraphEvaluationData,
 )
     lowered_model_def, reconstructed_model_def = JuliaBUGS._generate_lowered_model_def(
-        model_def, graph, evaluation_env
+        model_def,
+        graph,
+        evaluation_env;
+        generated_quantities=Set(graph_evaluation_data.generated_quantities),
     )
 
     if !isnothing(lowered_model_def)
@@ -611,9 +614,15 @@ function _regenerate_log_density_function(
             node in graph_evaluation_data.sorted_nodes
         end
 
-        # Update graph evaluation data with the correct sorted nodes
+        # Update graph evaluation data with the correct sorted nodes. Preserve the same
+        # generated-quantity classification that was used to generate the function above;
+        # otherwise the 3-argument constructor would re-derive it from the (possibly
+        # conditioned) graph and disagree with the generated code.
         updated_graph_evaluation_data = GraphEvaluationData(
-            graph, sorted_nodes, graph_evaluation_data.model_parameters
+            graph,
+            sorted_nodes,
+            graph_evaluation_data.model_parameters;
+            gq_override=Set(graph_evaluation_data.generated_quantities),
         )
 
         return new_log_density_computation_function, updated_graph_evaluation_data

--- a/JuliaBUGS/src/model/abstractppl.jl
+++ b/JuliaBUGS/src/model/abstractppl.jl
@@ -52,9 +52,10 @@ julia> model_def = @bugs begin
                x[i] ~ Normal(0, 1)
            end
            y ~ Normal(sum(x[:]), 1)
+           z ~ Normal(y, 1)
        end;
 
-julia> model = compile(model_def, (;));
+julia> model = compile(model_def, (; z=1.0));
 
 julia> # Basic conditioning
        model_cond = condition(model, Dict(@varname(x[1]) => 1.0, @varname(x[2]) => 2.0));
@@ -109,11 +110,11 @@ julia> sort(parameters(model_cond3); by=string)  # y removed, only x[i] remain
 
 julia> # Error cases
        try
-           condition(model, Dict(@varname(z) => 1.0))
+           condition(model, Dict(@varname(w) => 1.0))
        catch e
            println(e)
        end
-ArgumentError("Variable z does not exist in the model")
+ArgumentError("Variable w does not exist in the model")
 
 julia> # Using vector of VarNames (conditions using current values)
        model_init = initialize!(model, (; x=[1.0, 2.0, 3.0], y=4.0));
@@ -541,9 +542,13 @@ function _create_modified_model(
     new_evaluation_env::NamedTuple;
     base_model=nothing,
 )
-    # Create new graph evaluation data
-    new_graph_evaluation_data = GraphEvaluationData(new_graph)
-    new_parameters = new_graph_evaluation_data.sorted_parameters
+    # Create new graph evaluation data preserving the original GQ classification
+    # We must explicitly keep the original `generated_quantities` to avoid them being reclassified.
+    original_gq = Set(generated_quantities(
+        isnothing(model.base_model) ? model : model.base_model
+    ))
+    new_graph_evaluation_data = GraphEvaluationData(new_graph; gq_override=original_gq)
+    new_parameters = new_graph_evaluation_data.model_parameters
 
     # Calculate new parameter lengths
     new_untransformed_param_length, new_transformed_param_length = _calculate_param_lengths(
@@ -607,7 +612,9 @@ function _regenerate_log_density_function(
         end
 
         # Update graph evaluation data with the correct sorted nodes
-        updated_graph_evaluation_data = GraphEvaluationData(graph, sorted_nodes)
+        updated_graph_evaluation_data = GraphEvaluationData(
+            graph, sorted_nodes, graph_evaluation_data.model_parameters
+        )
 
         return new_log_density_computation_function, updated_graph_evaluation_data
     else

--- a/JuliaBUGS/src/model/abstractppl.jl
+++ b/JuliaBUGS/src/model/abstractppl.jl
@@ -542,17 +542,25 @@ function _create_modified_model(
     new_evaluation_env::NamedTuple;
     base_model=nothing,
 )
-    # Create new graph evaluation data preserving the original GQ classification
-    # We must explicitly keep the original `generated_quantities` to avoid them being reclassified.
-    original_gq = Set(
+    # Preserve the base model's generated-quantity policy, but only for variables
+    # that still have no observed descendants in the modified graph. Conditioning a
+    # former generated quantity makes it an observation, so its ancestors may need
+    # to move back into the model-parameter partition.
+    base_generated_quantities = Set(
         generated_quantities(isnothing(model.base_model) ? model : model.base_model)
     )
-    new_graph_evaluation_data = GraphEvaluationData(new_graph; gq_override=original_gq)
-    new_parameters = new_graph_evaluation_data.model_parameters
+    surviving_generated_quantities = find_generated_quantities_variables(new_graph)
+    new_graph_evaluation_data = GraphEvaluationData(
+        new_graph;
+        generated_quantities=intersect(
+            base_generated_quantities, surviving_generated_quantities
+        ),
+    )
+    new_model_parameters = new_graph_evaluation_data.model_parameters
 
     # Calculate new parameter lengths
     new_untransformed_param_length, new_transformed_param_length = _calculate_param_lengths(
-        model, new_parameters
+        model, new_model_parameters
     )
 
     # Recompute mutable symbols for the new graph
@@ -620,9 +628,8 @@ function _regenerate_log_density_function(
         # conditioned) graph and disagree with the generated code.
         updated_graph_evaluation_data = GraphEvaluationData(
             graph,
-            sorted_nodes,
-            graph_evaluation_data.model_parameters;
-            gq_override=Set(graph_evaluation_data.generated_quantities),
+            sorted_nodes;
+            generated_quantities=Set(graph_evaluation_data.generated_quantities),
         )
 
         return new_log_density_computation_function, updated_graph_evaluation_data

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -69,6 +69,7 @@ Stores pre-computed values to avoid repeated lookups from the MetaGraph during m
 - `model_parameters::Vector{<:VarName}`: Unobserved stochastic variables that influence observations
 - `generated_quantities::Vector{<:VarName}`: Variables (stochastic or deterministic) with no observed descendants
 - `variable_types::Vector{VariableType}`: Classification of each node
+- `is_model_parameter_vals::Vector{Bool}`: Whether each node is part of the MCMC parameter vector (true exactly for `model_parameters`)
 - `is_stochastic_vals::Vector{Bool}`: Whether each node represents a stochastic variable
 - `is_observed_vals::Vector{Bool}`: Whether each node is observed (has data)
 - `node_function_vals::TNF`: Functions that define each node's computation
@@ -80,6 +81,7 @@ struct GraphEvaluationData{TNF,TV}
     model_parameters::Vector{<:VarName}
     generated_quantities::Vector{<:VarName}
     variable_types::Vector{VariableType}
+    is_model_parameter_vals::Vector{Bool}
     is_stochastic_vals::Vector{Bool}
     is_observed_vals::Vector{Bool}
     node_function_vals::TNF
@@ -108,6 +110,7 @@ function GraphEvaluationData(
     model_parameters = VarName[]
     generated_quantities = VarName[]
     variable_types = Vector{VariableType}(undef, length(sorted_nodes))
+    is_model_parameter_vals = fill(false, length(sorted_nodes))
 
     if gq_override !== nothing
         gq_vars = gq_override
@@ -141,6 +144,7 @@ function GraphEvaluationData(
             if active_parameters === nothing || vn in active_parameters
                 push!(sorted_parameters, vn)
                 push!(model_parameters, vn)
+                is_model_parameter_vals[i] = true
             end
         end
     end
@@ -151,6 +155,7 @@ function GraphEvaluationData(
         model_parameters,
         generated_quantities,
         variable_types,
+        is_model_parameter_vals,
         is_stochastic_vals,
         is_observed_vals,
         map(identity, node_function_vals),
@@ -322,7 +327,6 @@ function BUGSModel(
     untransformed_param_length, transformed_param_length = 0, 0
     untransformed_var_lengths, transformed_var_lengths = Dict{VarName,Int}(),
     Dict{VarName,Int}()
-    sampled_vars = Set(graph_evaluation_data.model_parameters)
 
     for (i, vn) in enumerate(graph_evaluation_data.sorted_nodes)
         is_stochastic = graph_evaluation_data.is_stochastic_vals[i]
@@ -347,7 +351,7 @@ function BUGSModel(
                 else
                     length(Bijectors.transformed(dist))
                 end
-                if vn in sampled_vars
+                if graph_evaluation_data.is_model_parameter_vals[i]
                     untransformed_param_length += untransformed_var_lengths[vn]
                     transformed_param_length += transformed_var_lengths[vn]
                 end
@@ -420,7 +424,8 @@ Return the `VariableType` classification for variable `vn` in the model.
 function variable_type(model::BUGSModel, vn::VarName)
     gd = model.graph_evaluation_data
     idx = findfirst(==(vn), gd.sorted_nodes)
-    idx === nothing && throw(ArgumentError("Variable \"$(vn)\" does not exist in the model"))
+    idx === nothing &&
+        throw(ArgumentError("Variable \"$(vn)\" does not exist in the model"))
     return gd.variable_types[idx]
 end
 

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -38,7 +38,8 @@ Classification of each node in the model graph.
 - `Observation`: a stochastic node with observed data
 - `ModelParameter`: a stochastic node that influences observations (sampled by MCMC)
 - `TransformedParameter`: a deterministic node that needs to be computed during each iteration of sampling
-- `GeneratedQuantity`: a stochastic or deterministic node with no observed descendants (computed after getting samples)
+- `GeneratedQuantity`: a stochastic or deterministic node outside the log-density target
+  closure (computed after getting samples)
 """
 @enum VariableType Observation ModelParameter TransformedParameter GeneratedQuantity
 
@@ -51,7 +52,7 @@ Classification of each node in the model graph.
     return if is_stochastic && is_observed
         Observation
     elseif vn in generated_quantity_vars
-        # No observed descendants
+        # Outside the log-density target closure.
         GeneratedQuantity
     elseif is_stochastic
         # Stochastic node that influences observed likelihood terms.
@@ -60,6 +61,24 @@ Classification of each node in the model graph.
         # Deterministic node needed during each sampling iteration.
         TransformedParameter
     end
+end
+
+function _can_reach_stochastic(
+    g::BUGSGraph, vn::VarName, can_reach_stochastic::Dict{VarName,Bool}
+)
+    if haskey(can_reach_stochastic, vn)
+        return can_reach_stochastic[vn]
+    end
+
+    for child in MetaGraphsNext.outneighbor_labels(g, vn)
+        if g[child].is_stochastic || _can_reach_stochastic(g, child, can_reach_stochastic)
+            can_reach_stochastic[vn] = true
+            return true
+        end
+    end
+
+    can_reach_stochastic[vn] = false
+    return false
 end
 
 """
@@ -72,7 +91,7 @@ Stores pre-computed values to avoid repeated lookups from the MetaGraph during m
 - `sorted_nodes::Vector{<:VarName}`: Variables in topological order for evaluation
 - `sorted_parameters::Vector{<:VarName}`: Parameters (unobserved stochastic variables) in sorted order consistent with sorted_nodes
 - `model_parameters::Vector{<:VarName}`: Unobserved stochastic variables that influence observations
-- `generated_quantities::Vector{<:VarName}`: Variables (stochastic or deterministic) with no observed descendants
+- `generated_quantities::Vector{<:VarName}`: Variables (stochastic or deterministic) outside the log-density target closure
 - `variable_types::Vector{VariableType}`: Classification of each node
 - `is_model_parameter_vals::Vector{Bool}`: Whether each node is part of the MCMC parameter vector (true exactly for `model_parameters`)
 - `is_stochastic_vals::Vector{Bool}`: Whether each node represents a stochastic variable
@@ -136,12 +155,17 @@ function GraphEvaluationData(
         if !has_observations
             # Without observations every stochastic node trivially lacks observed
             # descendants, but those are priors to be sampled, not generated quantities.
-            # Deterministic nodes, however, are still genuine derived quantities, so keep
-            # them classified as generated quantities (e.g. for reporting in chains).
+            # Deterministic ancestors of those stochastic parameters are needed by the
+            # target and must be recomputed during log-density evaluation; only purely
+            # terminal deterministic derived quantities remain generated quantities.
             # `filter` preserves the `Set{VarName}` element type even when the result is
             # empty, which a generator comprehension would not.
+            can_reach_stochastic = Dict{VarName,Bool}()
             generated_quantity_vars = filter(
-                vn -> !g[vn].is_stochastic, generated_quantity_vars
+                vn ->
+                    !g[vn].is_stochastic &&
+                    !_can_reach_stochastic(g, vn, can_reach_stochastic),
+                generated_quantity_vars,
             )
         end
     end
@@ -438,7 +462,8 @@ model_parameters(model::BUGSModel) = model.graph_evaluation_data.model_parameter
 """
     generated_quantities(model::BUGSModel)
 
-Return a vector of `VarName` containing variables with no observed descendants. These can be computed after getting samples.
+Return a vector of `VarName` containing variables outside the log-density target
+closure. These can be computed after getting samples.
 """
 generated_quantities(model::BUGSModel) = model.graph_evaluation_data.generated_quantities
 

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -29,6 +29,35 @@ struct MarginalizationCache{V<:VarName}
 end
 
 """
+    VariableType
+
+Classification of each node in the model graph.
+
+- `Observation`: a stochastic node with observed data
+- `ModelParameter`: a stochastic node that influences observations (sampled by MCMC)
+- `TransformedParameter`: a deterministic node that needs to be computed during each iteration of sampling
+- `GeneratedQuantity`: a stochastic or deterministic node with no observed descendants (computed after getting samples)
+"""
+@enum VariableType Observation ModelParameter TransformedParameter GeneratedQuantity
+
+@inline function _classify_variable_type(
+    vn::VarName, is_stochastic::Bool, is_observed::Bool, gq_vars::Set{<:VarName}
+)
+    return if is_stochastic && is_observed
+        Observation
+    elseif vn in gq_vars
+        # No observed descendants
+        GeneratedQuantity
+    elseif is_stochastic
+        # Stochastic node that influences observed likelihood terms.
+        ModelParameter
+    else
+        # Deterministic node needed during each sampling iteration.
+        TransformedParameter
+    end
+end
+
+"""
     GraphEvaluationData{TNF,TV}
 
 Caches node information from the model graph to optimize evaluation performance.
@@ -37,6 +66,9 @@ Stores pre-computed values to avoid repeated lookups from the MetaGraph during m
 # Fields
 - `sorted_nodes::Vector{<:VarName}`: Variables in topological order for evaluation
 - `sorted_parameters::Vector{<:VarName}`: Parameters (unobserved stochastic variables) in sorted order consistent with sorted_nodes
+- `model_parameters::Vector{<:VarName}`: Unobserved stochastic variables that influence observations
+- `generated_quantities::Vector{<:VarName}`: Variables (stochastic or deterministic) with no observed descendants
+- `variable_types::Vector{VariableType}`: Classification of each node
 - `is_stochastic_vals::Vector{Bool}`: Whether each node represents a stochastic variable
 - `is_observed_vals::Vector{Bool}`: Whether each node is observed (has data)
 - `node_function_vals::TNF`: Functions that define each node's computation
@@ -45,6 +77,9 @@ Stores pre-computed values to avoid repeated lookups from the MetaGraph during m
 struct GraphEvaluationData{TNF,TV}
     sorted_nodes::Vector{<:VarName}
     sorted_parameters::Vector{<:VarName}
+    model_parameters::Vector{<:VarName}
+    generated_quantities::Vector{<:VarName}
+    variable_types::Vector{VariableType}
     is_stochastic_vals::Vector{Bool}
     is_observed_vals::Vector{Bool}
     node_function_vals::TNF
@@ -69,6 +104,11 @@ function GraphEvaluationData(
     node_function_vals = Array{Any}(undef, length(sorted_nodes))
     loop_vars_vals = Array{Any}(undef, length(sorted_nodes))
     sorted_parameters = VarName[]
+    model_parameters = VarName[]
+    generated_quantities = VarName[]
+    variable_types = Vector{VariableType}(undef, length(sorted_nodes))
+
+    gq_vars = find_generated_quantities_variables(g)
 
     for (i, vn) in enumerate(sorted_nodes)
         (; is_stochastic, is_observed, node_function, loop_vars) = g[vn]
@@ -77,11 +117,21 @@ function GraphEvaluationData(
         node_function_vals[i] = node_function
         loop_vars_vals[i] = loop_vars
 
-        # If it's a stochastic variable and not observed, it's a parameter
-        # If active_parameters is specified, only include those that are in the list
-        if is_stochastic && !is_observed
+        # Classify each node
+        variable_types[i] = _classify_variable_type(vn, is_stochastic, is_observed, gq_vars)
+
+        if variable_types[i] == GeneratedQuantity
+            # Both stochastic and deterministic nodes go here
+            push!(generated_quantities, vn)
+            if is_stochastic && !is_observed
+                if active_parameters === nothing || vn in active_parameters
+                    push!(sorted_parameters, vn)
+                end
+            end
+        elseif is_stochastic && !is_observed
             if active_parameters === nothing || vn in active_parameters
                 push!(sorted_parameters, vn)
+                push!(model_parameters, vn)
             end
         end
     end
@@ -89,6 +139,9 @@ function GraphEvaluationData(
     return GraphEvaluationData{typeof(node_function_vals),typeof(loop_vars_vals)}(
         sorted_nodes,
         sorted_parameters,
+        model_parameters,
+        generated_quantities,
+        variable_types,
         is_stochastic_vals,
         is_observed_vals,
         map(identity, node_function_vals),
@@ -331,6 +384,33 @@ end
 Return a vector of `VarName` containing the names of the model parameters (unobserved stochastic variables).
 """
 parameters(model::BUGSModel) = model.graph_evaluation_data.sorted_parameters
+
+"""
+    model_parameters(model::BUGSModel)
+
+Return a vector of `VarName` containing the stochastic variables that influence observations
+and should be sampled directly.
+"""
+model_parameters(model::BUGSModel) = model.graph_evaluation_data.model_parameters
+
+"""
+    generated_quantities(model::BUGSModel)
+
+Return a vector of `VarName` containing variables with no observed descendants. These can be computed after getting samples.
+"""
+generated_quantities(model::BUGSModel) = model.graph_evaluation_data.generated_quantities
+
+"""
+    variable_type(model::BUGSModel, vn::VarName)
+
+Return the `VariableType` classification for variable `vn` in the model.
+"""
+function variable_type(model::BUGSModel, vn::VarName)
+    gd = model.graph_evaluation_data
+    idx = findfirst(==(vn), gd.sorted_nodes)
+    idx === nothing && throw(ArgumentError("Variable \"$(vn)\" does not exist in the model"))
+    return gd.variable_types[idx]
+end
 
 """
     variables(model::BUGSModel)

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -18,6 +18,7 @@ must be invalidated when the graph structure changes (e.g., during conditioning)
 - `param_lengths::Dict{VarName,Int}`: Transformed lengths for continuous parameters.
 - `param_offsets::Dict{VarName,Int}`: Start index in flattened parameter vector for each continuous param.
 - `n_discrete_finite::Int`: Number of discrete finite variables (for memo sizing).
+- `continuous_model_parameters::Vector{VarName}`: Continuous model parameters that remain in the flat parameter vector after marginalization.
 """
 struct MarginalizationCache{V<:VarName}
     minimal_cache_keys::Dict{Int,Vector{Int}}
@@ -26,6 +27,7 @@ struct MarginalizationCache{V<:VarName}
     param_lengths::Dict{V,Int}
     param_offsets::Dict{V,Int}
     n_discrete_finite::Int
+    continuous_model_parameters::Vector{V}
 end
 
 """
@@ -41,11 +43,14 @@ Classification of each node in the model graph.
 @enum VariableType Observation ModelParameter TransformedParameter GeneratedQuantity
 
 @inline function _classify_variable_type(
-    vn::VarName, is_stochastic::Bool, is_observed::Bool, gq_vars::Set{<:VarName}
+    vn::VarName,
+    is_stochastic::Bool,
+    is_observed::Bool,
+    generated_quantity_vars::Set{<:VarName},
 )
     return if is_stochastic && is_observed
         Observation
-    elseif vn in gq_vars
+    elseif vn in generated_quantity_vars
         # No observed descendants
         GeneratedQuantity
     elseif is_stochastic
@@ -89,10 +94,21 @@ struct GraphEvaluationData{TNF,TV}
 end
 
 """
-    GraphEvaluationData(g::BUGSGraph, [sorted_nodes], [active_parameters])
+    GraphEvaluationData(g::BUGSGraph, [sorted_nodes], [active_parameters]; [generated_quantities])
 
 Create a `GraphEvaluationData` from a `BUGSGraph`, extracting and caching node information
 for efficient evaluation.
+
+`sorted_nodes` gives the evaluation order and defaults to the graph's topological order.
+`active_parameters`, when provided, is a filter for the parameter lists: only unobserved
+stochastic variables in that vector are added to `sorted_parameters`; non-generated
+stochastic variables outside the filter are also left out of `model_parameters`.
+
+`generated_quantities` optionally supplies the set of variables to classify as
+`GeneratedQuantity`. When it is `nothing`, the set is derived from the graph. Passing it
+is useful when rebuilding graph evaluation data after conditioning or source generation,
+where the caller needs the cached classification to match the classification used by the
+existing model.
 """
 function GraphEvaluationData(
     g::BUGSGraph,
@@ -100,7 +116,7 @@ function GraphEvaluationData(
         label_for(g, node) for node in topological_sort(g)
     ],
     active_parameters::Union{Nothing,Vector{<:VarName}}=nothing;
-    gq_override::Union{Nothing,Set{<:VarName}}=nothing,
+    generated_quantities::Union{Nothing,Set{<:VarName}}=nothing,
 )
     is_stochastic_vals = Array{Bool}(undef, length(sorted_nodes))
     is_observed_vals = Array{Bool}(undef, length(sorted_nodes))
@@ -108,17 +124,25 @@ function GraphEvaluationData(
     loop_vars_vals = Array{Any}(undef, length(sorted_nodes))
     sorted_parameters = VarName[]
     model_parameters = VarName[]
-    generated_quantities = VarName[]
+    generated_quantity_nodes = VarName[]
     variable_types = Vector{VariableType}(undef, length(sorted_nodes))
     is_model_parameter_vals = fill(false, length(sorted_nodes))
 
-    if gq_override !== nothing
-        gq_vars = gq_override
+    if generated_quantities !== nothing
+        generated_quantity_vars = generated_quantities
     else
-        gq_vars = find_generated_quantities_variables(g)
+        generated_quantity_vars = find_generated_quantities_variables(g)
         has_observations = any(g[vn].is_observed for vn in labels(g) if g[vn].is_stochastic)
         if !has_observations
-            gq_vars = Set{VarName}()
+            # Without observations every stochastic node trivially lacks observed
+            # descendants, but those are priors to be sampled, not generated quantities.
+            # Deterministic nodes, however, are still genuine derived quantities, so keep
+            # them classified as generated quantities (e.g. for reporting in chains).
+            # `filter` preserves the `Set{VarName}` element type even when the result is
+            # empty, which a generator comprehension would not.
+            generated_quantity_vars = filter(
+                vn -> !g[vn].is_stochastic, generated_quantity_vars
+            )
         end
     end
 
@@ -130,11 +154,13 @@ function GraphEvaluationData(
         loop_vars_vals[i] = loop_vars
 
         # Classify each node
-        variable_types[i] = _classify_variable_type(vn, is_stochastic, is_observed, gq_vars)
+        variable_types[i] = _classify_variable_type(
+            vn, is_stochastic, is_observed, generated_quantity_vars
+        )
 
         if variable_types[i] == GeneratedQuantity
             # Both stochastic and deterministic nodes go here
-            push!(generated_quantities, vn)
+            push!(generated_quantity_nodes, vn)
             if is_stochastic && !is_observed
                 if active_parameters === nothing || vn in active_parameters
                     push!(sorted_parameters, vn)
@@ -153,7 +179,7 @@ function GraphEvaluationData(
         sorted_nodes,
         sorted_parameters,
         model_parameters,
-        generated_quantities,
+        generated_quantity_nodes,
         variable_types,
         is_model_parameter_vals,
         is_stochastic_vals,
@@ -490,34 +516,6 @@ function initialize!(model::BUGSModel, initial_params::AbstractVector)
 end
 
 """
-    _active_parameters(model::BUGSModel)
-
-In `UseAutoMarginalization` mode, this filters out discrete variables that are being marginalized.
-Otherwise, it returns `model_parameters(model)`.
-"""
-function _active_parameters(model::BUGSModel)
-    if model.evaluation_mode isa UseAutoMarginalization
-        gd = model.graph_evaluation_data
-        mc = model.marginalization_cache
-        return filter(model_parameters(model)) do vn
-            idx = findfirst(==(vn), gd.sorted_nodes)
-            if idx !== nothing
-                node_type = mc.node_types[idx]
-                if node_type == :discrete_infinite
-                    error(
-                        "Model contains discrete infinite variable $(vn) which cannot be marginalized. " *
-                        "Use UseGraph evaluation mode instead.",
-                    )
-                end
-                return node_type == :continuous
-            end
-            return false
-        end
-    end
-    return model_parameters(model)
-end
-
-"""
     getparams([T::Type], model::BUGSModel, evaluation_env=model.evaluation_env)
 
 Extract parameter values from the model.
@@ -552,7 +550,11 @@ params_dict = getparams(Dict, model, custom_env)
 ```
 """
 function getparams(model::BUGSModel, evaluation_env=model.evaluation_env)
-    param_vars = _active_parameters(model)
+    param_vars = if model.evaluation_mode isa UseAutoMarginalization
+        model.marginalization_cache.continuous_model_parameters
+    else
+        model_parameters(model)
+    end
 
     # Compute total length for allocation
     param_length = 0
@@ -599,7 +601,11 @@ function getparams(
     T::Type{<:AbstractDict}, model::BUGSModel, evaluation_env=model.evaluation_env
 )
     d = T()
-    param_vars = _active_parameters(model)
+    param_vars = if model.evaluation_mode isa UseAutoMarginalization
+        model.marginalization_cache.continuous_model_parameters
+    else
+        model_parameters(model)
+    end
     for v in param_vars
         value = AbstractPPL.getvalue(evaluation_env, v)
         if !model.transformed
@@ -710,9 +716,10 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                 # conditioned models).
                 new_gd = GraphEvaluationData(
                     model.g,
-                    sorted_nodes,
-                    model.graph_evaluation_data.model_parameters;
-                    gq_override=Set(model.graph_evaluation_data.generated_quantities),
+                    sorted_nodes;
+                    generated_quantities=Set(
+                        model.graph_evaluation_data.generated_quantities
+                    ),
                 )
 
                 model = BangBang.setproperty!!(model, :graph_evaluation_data, new_gd)
@@ -753,21 +760,38 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                 vn_to_idx = Dict(sorted_nodes[i] => i for i in eachindex(sorted_nodes))
                 param_lengths = Dict{eltype(sorted_nodes),Int}()
                 param_offsets = Dict{eltype(sorted_nodes),Int}()
+                continuous_model_parameters = eltype(sorted_nodes)[]
                 offset = 1
                 for vn in gd.model_parameters
                     idx = get(vn_to_idx, vn, 0)
-                    if idx != 0 && node_types[idx] == :continuous
-                        len = model.transformed_var_lengths[vn]
-                        param_lengths[vn] = len
-                        param_offsets[vn] = offset
-                        offset += len
+                    if idx != 0
+                        node_type = node_types[idx]
+                        if node_type == :discrete_infinite
+                            error(
+                                "Model contains discrete infinite variable $(vn) which cannot be marginalized. " *
+                                "Use UseGraph evaluation mode instead.",
+                            )
+                        end
+                        if node_type == :continuous
+                            len = model.transformed_var_lengths[vn]
+                            param_lengths[vn] = len
+                            param_offsets[vn] = offset
+                            offset += len
+                            push!(continuous_model_parameters, vn)
+                        end
                     end
                 end
 
                 n_discrete_finite = count(==(:discrete_finite), node_types)
 
                 cache = MarginalizationCache(
-                    keys, order, node_types, param_lengths, param_offsets, n_discrete_finite
+                    keys,
+                    order,
+                    node_types,
+                    param_lengths,
+                    param_offsets,
+                    n_discrete_finite,
+                    continuous_model_parameters,
                 )
                 model = BangBang.setproperty!!(model, :marginalization_cache, cache)
             catch err

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -672,7 +672,10 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
         # Lazily generate log density function if not already present
         if isnothing(model.log_density_computation_function)
             lowered_model_def, reconstructed_model_def = JuliaBUGS._generate_lowered_model_def(
-                model.model_def, model.g, model.evaluation_env
+                model.model_def,
+                model.g,
+                model.evaluation_env;
+                generated_quantities=Set(model.graph_evaluation_data.generated_quantities),
             )
             if isnothing(lowered_model_def)
                 @warn(
@@ -700,9 +703,16 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                     node in gd.sorted_nodes
                 end
 
-                # Create fresh GraphEvaluationData for the new order
+                # Create fresh GraphEvaluationData for the new order. Preserve the same
+                # generated-quantity classification used to generate the function above so
+                # the stored data and the generated code agree (the 3-argument constructor
+                # would otherwise re-derive GQ from the graph and disagree on, e.g.,
+                # conditioned models).
                 new_gd = GraphEvaluationData(
-                    model.g, sorted_nodes, model.graph_evaluation_data.model_parameters
+                    model.g,
+                    sorted_nodes,
+                    model.graph_evaluation_data.model_parameters;
+                    gq_override=Set(model.graph_evaluation_data.generated_quantities),
                 )
 
                 model = BangBang.setproperty!!(model, :graph_evaluation_data, new_gd)

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -97,7 +97,8 @@ function GraphEvaluationData(
     sorted_nodes::Vector{<:VarName}=VarName[
         label_for(g, node) for node in topological_sort(g)
     ],
-    active_parameters::Union{Nothing,Vector{<:VarName}}=nothing,
+    active_parameters::Union{Nothing,Vector{<:VarName}}=nothing;
+    gq_override::Union{Nothing,Set{<:VarName}}=nothing,
 )
     is_stochastic_vals = Array{Bool}(undef, length(sorted_nodes))
     is_observed_vals = Array{Bool}(undef, length(sorted_nodes))
@@ -108,7 +109,15 @@ function GraphEvaluationData(
     generated_quantities = VarName[]
     variable_types = Vector{VariableType}(undef, length(sorted_nodes))
 
-    gq_vars = find_generated_quantities_variables(g)
+    if gq_override !== nothing
+        gq_vars = gq_override
+    else
+        gq_vars = find_generated_quantities_variables(g)
+        has_observations = any(g[vn].is_observed for vn in labels(g) if g[vn].is_stochastic)
+        if !has_observations
+            gq_vars = Set{VarName}()
+        end
+    end
 
     for (i, vn) in enumerate(sorted_nodes)
         (; is_stochastic, is_observed, node_function, loop_vars) = g[vn]
@@ -313,6 +322,7 @@ function BUGSModel(
     untransformed_param_length, transformed_param_length = 0, 0
     untransformed_var_lengths, transformed_var_lengths = Dict{VarName,Int}(),
     Dict{VarName,Int}()
+    sampled_vars = Set(graph_evaluation_data.model_parameters)
 
     for (i, vn) in enumerate(graph_evaluation_data.sorted_nodes)
         is_stochastic = graph_evaluation_data.is_stochastic_vals[i]
@@ -337,8 +347,10 @@ function BUGSModel(
                 else
                     length(Bijectors.transformed(dist))
                 end
-                untransformed_param_length += untransformed_var_lengths[vn]
-                transformed_param_length += transformed_var_lengths[vn]
+                if vn in sampled_vars
+                    untransformed_param_length += untransformed_var_lengths[vn]
+                    transformed_param_length += transformed_var_lengths[vn]
+                end
 
                 if haskey(initial_params, AbstractPPL.getsym(vn))
                     initialization = AbstractPPL.getvalue(initial_params, vn)
@@ -381,7 +393,7 @@ end
 """
     parameters(model::BUGSModel)
 
-Return a vector of `VarName` containing the names of the model parameters (unobserved stochastic variables).
+Return a vector of `VarName` containing the names of all unobserved stochastic variables.
 """
 parameters(model::BUGSModel) = model.graph_evaluation_data.sorted_parameters
 
@@ -473,6 +485,34 @@ function initialize!(model::BUGSModel, initial_params::AbstractVector)
 end
 
 """
+    _active_parameters(model::BUGSModel)
+
+In `UseAutoMarginalization` mode, this filters out discrete variables that are being marginalized.
+Otherwise, it returns `model_parameters(model)`.
+"""
+function _active_parameters(model::BUGSModel)
+    if model.evaluation_mode isa UseAutoMarginalization
+        gd = model.graph_evaluation_data
+        mc = model.marginalization_cache
+        return filter(model_parameters(model)) do vn
+            idx = findfirst(==(vn), gd.sorted_nodes)
+            if idx !== nothing
+                node_type = mc.node_types[idx]
+                if node_type == :discrete_infinite
+                    error(
+                        "Model contains discrete infinite variable $(vn) which cannot be marginalized. " *
+                        "Use UseGraph evaluation mode instead.",
+                    )
+                end
+                return node_type == :continuous
+            end
+            return false
+        end
+    end
+    return model_parameters(model)
+end
+
+"""
     getparams([T::Type], model::BUGSModel, evaluation_env=model.evaluation_env)
 
 Extract parameter values from the model.
@@ -507,18 +547,7 @@ params_dict = getparams(Dict, model, custom_env)
 ```
 """
 function getparams(model::BUGSModel, evaluation_env=model.evaluation_env)
-    # Determine which parameters to include based on evaluation mode
-    gd = model.graph_evaluation_data
-    param_vars = if model.evaluation_mode isa UseAutoMarginalization
-        # Only include continuous parameters when auto marginalizing
-        mc = model.marginalization_cache
-        filter(gd.sorted_parameters) do vn
-            idx = findfirst(==(vn), gd.sorted_nodes)
-            idx !== nothing && mc.node_types[idx] == :continuous
-        end
-    else
-        gd.sorted_parameters
-    end
+    param_vars = _active_parameters(model)
 
     # Compute total length for allocation
     param_length = 0
@@ -565,17 +594,7 @@ function getparams(
     T::Type{<:AbstractDict}, model::BUGSModel, evaluation_env=model.evaluation_env
 )
     d = T()
-    gd = model.graph_evaluation_data
-    # Respect evaluation mode when selecting parameters
-    param_vars = if model.evaluation_mode isa UseAutoMarginalization
-        mc = model.marginalization_cache
-        filter(gd.sorted_parameters) do vn
-            idx = findfirst(==(vn), gd.sorted_nodes)
-            idx !== nothing && mc.node_types[idx] == :continuous
-        end
-    else
-        gd.sorted_parameters
-    end
+    param_vars = _active_parameters(model)
     for v in param_vars
         value = AbstractPPL.getvalue(evaluation_env, v)
         if !model.transformed
@@ -677,7 +696,9 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                 end
 
                 # Create fresh GraphEvaluationData for the new order
-                new_gd = GraphEvaluationData(model.g, sorted_nodes)
+                new_gd = GraphEvaluationData(
+                    model.g, sorted_nodes, model.graph_evaluation_data.model_parameters
+                )
 
                 model = BangBang.setproperty!!(model, :graph_evaluation_data, new_gd)
                 model = BangBang.setproperty!!(
@@ -718,7 +739,7 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                 param_lengths = Dict{eltype(sorted_nodes),Int}()
                 param_offsets = Dict{eltype(sorted_nodes),Int}()
                 offset = 1
-                for vn in gd.sorted_parameters
+                for vn in gd.model_parameters
                     idx = get(vn_to_idx, vn, 0)
                     if idx != 0 && node_types[idx] == :continuous
                         len = model.transformed_var_lengths[vn]

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -54,6 +54,7 @@ function evaluate_with_rng!!(
     sample_observed=false,
     temperature=1.0,
     transformed=true,
+    include_generated_quantities=false,
 )
     logprior = 0.0
     loglikelihood = 0.0
@@ -91,7 +92,8 @@ function evaluate_with_rng!!(
 
             if is_observed
                 loglikelihood += logp
-            else
+            elseif include_generated_quantities ||
+                model.graph_evaluation_data.is_model_parameter_vals[i]
                 logprior += logp
             end
 
@@ -135,11 +137,6 @@ function evaluate_with_env!!(
 )
     logprior = 0.0
     loglikelihood = 0.0
-    sampled_vars = if include_generated_quantities
-        Set(model.graph_evaluation_data.sorted_parameters)
-    else
-        Set(model.graph_evaluation_data.model_parameters)
-    end
 
     for (i, vn) in enumerate(model.graph_evaluation_data.sorted_nodes)
         is_stochastic = model.graph_evaluation_data.is_stochastic_vals[i]
@@ -169,7 +166,8 @@ function evaluate_with_env!!(
 
             if is_observed
                 loglikelihood += logp
-            elseif vn in sampled_vars
+            elseif include_generated_quantities ||
+                model.graph_evaluation_data.is_model_parameter_vals[i]
                 logprior += logp
             end
         end
@@ -213,7 +211,6 @@ function evaluate_with_values!!(
     end
 
     evaluation_env = smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols)
-    sampled_vars = Set(model.graph_evaluation_data.model_parameters)
     current_idx = 1
     logprior, loglikelihood = 0.0, 0.0
     for (i, vn) in enumerate(model.graph_evaluation_data.sorted_nodes)
@@ -224,38 +221,33 @@ function evaluate_with_values!!(
         if !is_stochastic
             value = node_function(evaluation_env, loop_vars)
             evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
+        elseif !is_observed && model.graph_evaluation_data.is_model_parameter_vals[i]
+            dist = node_function(evaluation_env, loop_vars)
+            l = var_lengths[vn]
+            if transformed
+                b = Bijectors.bijector(dist)
+                b_inv = Bijectors.inverse(b)
+                reconstructed_value = reconstruct(
+                    b_inv, dist, view(flattened_values, current_idx:(current_idx + l - 1))
+                )
+                value, logjac = Bijectors.with_logabsdet_jacobian(
+                    b_inv, reconstructed_value
+                )
+            else
+                value = reconstruct(
+                    dist, view(flattened_values, current_idx:(current_idx + l - 1))
+                )
+                logjac = 0.0
+            end
+            current_idx += l
+            logprior += logpdf(dist, value) + logjac
+            evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
+        elseif !is_observed
+            # Generated quantity: not part of the MCMC parameter vector. Leave its
+            # current env value untouched here; it is forward-sampled separately.
         else
             dist = node_function(evaluation_env, loop_vars)
-            if !is_observed && vn in sampled_vars
-                l = var_lengths[vn]
-                if transformed
-                    b = Bijectors.bijector(dist)
-                    b_inv = Bijectors.inverse(b)
-                    reconstructed_value = reconstruct(
-                        b_inv,
-                        dist,
-                        view(flattened_values, current_idx:(current_idx + l - 1)),
-                    )
-                    value, logjac = Bijectors.with_logabsdet_jacobian(
-                        b_inv, reconstructed_value
-                    )
-                else
-                    value = reconstruct(
-                        dist, view(flattened_values, current_idx:(current_idx + l - 1))
-                    )
-                    logjac = 0.0
-                end
-                current_idx += l
-                logprior += logpdf(dist, value) + logjac
-                evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
-            elseif !is_observed
-                # Postprocessed stochastic variables are not part of parameter vectors
-                # and should not contribute to the sampled target density.
-                value = AbstractPPL.getvalue(evaluation_env, vn)
-                evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
-            else
-                loglikelihood += logpdf(dist, AbstractPPL.getvalue(evaluation_env, vn))
-            end
+            loglikelihood += logpdf(dist, AbstractPPL.getvalue(evaluation_env, vn))
         end
     end
     return evaluation_env,
@@ -297,9 +289,8 @@ end
 Return the finite support for a discrete univariate distribution.
 Relies on Distributions.support to provide an iterable, finite range.
 """
-_enumerate_discrete_values(dist::Distributions.DiscreteUnivariateDistribution) = Distributions.support(
-    dist
-)
+_enumerate_discrete_values(dist::Distributions.DiscreteUnivariateDistribution) =
+    Distributions.support(dist)
 
 """
     _classify_node_type(dist)

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -80,21 +80,25 @@ function evaluate_with_rng!!(
                 value = rand(rng, dist)
             end
 
-            if transformed
-                value_transformed = Bijectors.transform(Bijectors.bijector(dist), value)
-                logp =
+            should_score =
+                is_observed ||
+                include_generated_quantities ||
+                model.graph_evaluation_data.is_model_parameter_vals[i]
+            if should_score
+                logp = if transformed
+                    value_transformed = Bijectors.transform(Bijectors.bijector(dist), value)
                     Distributions.logpdf(dist, value) + Bijectors.logabsdetjac(
                         Bijectors.inverse(Bijectors.bijector(dist)), value_transformed
                     )
-            else
-                logp = Distributions.logpdf(dist, value)
-            end
+                else
+                    Distributions.logpdf(dist, value)
+                end
 
-            if is_observed
-                loglikelihood += logp
-            elseif include_generated_quantities ||
-                model.graph_evaluation_data.is_model_parameter_vals[i]
-                logprior += logp
+                if is_observed
+                    loglikelihood += logp
+                else
+                    logprior += logp
+                end
             end
 
             evaluation_env = setindex!!(evaluation_env, value, vn)
@@ -144,7 +148,10 @@ function evaluate_with_env!!(
         node_function = model.graph_evaluation_data.node_function_vals[i]
         loop_vars = model.graph_evaluation_data.loop_vars_vals[i]
 
-        if !is_stochastic
+        if model.graph_evaluation_data.variable_types[i] == GeneratedQuantity &&
+            !include_generated_quantities
+            continue
+        elseif !is_stochastic
             value = node_function(evaluation_env, loop_vars)
             evaluation_env = setindex!!(evaluation_env, value, vn)
         else
@@ -218,7 +225,9 @@ function evaluate_with_values!!(
         is_observed = model.graph_evaluation_data.is_observed_vals[i]
         node_function = model.graph_evaluation_data.node_function_vals[i]
         loop_vars = model.graph_evaluation_data.loop_vars_vals[i]
-        if !is_stochastic
+        if model.graph_evaluation_data.variable_types[i] == GeneratedQuantity
+            continue
+        elseif !is_stochastic
             value = node_function(evaluation_env, loop_vars)
             evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
         elseif !is_observed && model.graph_evaluation_data.is_model_parameter_vals[i]
@@ -315,11 +324,11 @@ end
 Forward-sample the generated quantities of `model` given an environment that already holds
 the model parameters, observations, and transformed parameters.
 
-Generated quantities are the nodes with no observed descendants. Stochastic ones are drawn
-from their conditional distribution given their (already-set) parents (`rand`); deterministic
-ones are recomputed. Model parameters, observations, and transformed parameters are left
-untouched. Nodes are visited in topological order, so chains of generated quantities are
-sampled with their parents already in place.
+Generated quantities are the nodes outside the log-density target dependency closure.
+Stochastic ones are drawn from their conditional distribution given their (already-set)
+parents (`rand`); deterministic ones are recomputed. Model parameters, observations, and
+transformed parameters are left untouched. Nodes are visited in topological order, so chains
+of generated quantities are sampled with their parents already in place.
 
 If `model` is in `UseAutoMarginalization` mode its discrete latents were summed out of the
 log density and have no value in `evaluation_env`. A generated quantity may depend on such a
@@ -750,7 +759,7 @@ function _marginalize_recursive(
     rest_indices = @view(remaining_indices[2:end])
 
     result = if gd.variable_types[current_idx] == GeneratedQuantity
-        # Generated quantities have no observed descendants, so the whole generated-quantity
+        # Generated quantities are outside the target closure, so the generated-quantity
         # block integrates/sums to one and factors out of the marginalized target p(θ, y).
         # Skip it entirely: don't read the parameter vector (it has no slot there) and don't
         # marginalize it. They are recovered later by forward sampling, not here.

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -279,10 +279,10 @@ function _evaluate_active_parameters_with_values!!(
         if gd.variable_types[i] == GeneratedQuantity
             continue
         elseif !gd.is_stochastic_vals[i]
-            value = Base.invokelatest(node_function, evaluation_env, loop_vars)
+            value = node_function(evaluation_env, loop_vars)
             evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
         elseif !gd.is_observed_vals[i] && vn in active_parameters
-            dist = Base.invokelatest(node_function, evaluation_env, loop_vars)
+            dist = node_function(evaluation_env, loop_vars)
             l = var_lengths[vn]
             value = if transformed
                 b_inv = Bijectors.inverse(Bijectors.bijector(dist))

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -258,6 +258,48 @@ function evaluate_with_values!!(
     )
 end
 
+"""
+    forward_sample_generated_quantities!!(
+        rng::Random.AbstractRNG,
+        model::BUGSModel,
+        evaluation_env=smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols),
+    )
+
+Forward-sample the generated quantities of `model` given an environment that already holds
+the model parameters, observations, and transformed parameters.
+
+Generated quantities are the nodes with no observed descendants. Stochastic ones are drawn
+from their conditional distribution given their (already-set) parents (`rand`); deterministic
+ones are recomputed. Model parameters, observations, and transformed parameters are left
+untouched. Nodes are visited in topological order, so chains of generated quantities are
+sampled with their parents already in place.
+
+This is the post-processing step that turns a posterior draw of the model parameters into a
+joint posterior(-predictive) draw that also includes the generated quantities.
+
+# Returns
+- `evaluation_env`: The environment with generated-quantity values filled in.
+"""
+function forward_sample_generated_quantities!!(
+    rng::Random.AbstractRNG,
+    model::BUGSModel,
+    evaluation_env=smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols),
+)
+    gd = model.graph_evaluation_data
+    for (i, vn) in enumerate(gd.sorted_nodes)
+        gd.variable_types[i] == GeneratedQuantity || continue
+        node_function = gd.node_function_vals[i]
+        loop_vars = gd.loop_vars_vals[i]
+        value = if gd.is_stochastic_vals[i]
+            rand(rng, node_function(evaluation_env, loop_vars))
+        else
+            node_function(evaluation_env, loop_vars)
+        end
+        evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
+    end
+    return evaluation_env
+end
+
 # ======================
 # Marginalization Support
 # ======================

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -258,6 +258,51 @@ function evaluate_with_values!!(
     )
 end
 
+function _evaluate_active_parameters_with_values!!(
+    model::BUGSModel, flattened_values::AbstractVector; transformed=true
+)
+    var_lengths = if transformed
+        model.transformed_var_lengths
+    else
+        model.untransformed_var_lengths
+    end
+
+    evaluation_env = smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols)
+    active_parameters = Set(_active_parameters(model))
+    current_idx = 1
+
+    gd = model.graph_evaluation_data
+    for (i, vn) in enumerate(gd.sorted_nodes)
+        node_function = gd.node_function_vals[i]
+        loop_vars = gd.loop_vars_vals[i]
+
+        if gd.variable_types[i] == GeneratedQuantity
+            continue
+        elseif !gd.is_stochastic_vals[i]
+            value = Base.invokelatest(node_function, evaluation_env, loop_vars)
+            evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
+        elseif !gd.is_observed_vals[i] && vn in active_parameters
+            dist = Base.invokelatest(node_function, evaluation_env, loop_vars)
+            l = var_lengths[vn]
+            value = if transformed
+                b_inv = Bijectors.inverse(Bijectors.bijector(dist))
+                reconstructed_value = reconstruct(
+                    b_inv,
+                    dist,
+                    view(flattened_values, current_idx:(current_idx + l - 1)),
+                )
+                first(Bijectors.with_logabsdet_jacobian(b_inv, reconstructed_value))
+            else
+                reconstruct(dist, view(flattened_values, current_idx:(current_idx + l - 1)))
+            end
+            current_idx += l
+            evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
+        end
+    end
+
+    return evaluation_env
+end
+
 """
     forward_sample_generated_quantities!!(
         rng::Random.AbstractRNG,
@@ -865,7 +910,9 @@ function evaluate_with_marginalization_values!!(
     memo = Dict{Tuple{Int,Tuple},Tuple{T,T}}()
     sizehint!(memo, expected_entries)
 
-    evaluation_env = smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols)
+    evaluation_env = _evaluate_active_parameters_with_values!!(
+        model, flattened_values; transformed=model.transformed
+    )
 
     log_prior, log_likelihood = _marginalize_recursive(
         model,

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -278,7 +278,7 @@ If `model` is in `UseAutoMarginalization` mode its discrete latents were summed 
 log density and have no value in `evaluation_env`. A generated quantity may depend on such a
 latent (directly or indirectly), so before forward-sampling, the marginalized discrete
 latents are first recovered by sampling from their conditional posterior
-`p(z | θ, y)` (see [`_sample_discrete_latents!!`](@ref)). Generated quantities with no
+`p(z | θ, y)` (see `_sample_discrete_latents!!`). Generated quantities with no
 marginalized-discrete ancestor are unaffected by this step.
 
 This is the post-processing step that turns a posterior draw of the model parameters into a

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -258,7 +258,7 @@ function evaluate_with_values!!(
     )
 end
 
-function _evaluate_active_parameters_with_values!!(
+function _evaluate_continuous_model_parameters_with_values!!(
     model::BUGSModel, flattened_values::AbstractVector; transformed=true
 )
     var_lengths = if transformed
@@ -268,7 +268,9 @@ function _evaluate_active_parameters_with_values!!(
     end
 
     evaluation_env = smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols)
-    active_parameters = Set(_active_parameters(model))
+    continuous_model_parameters = Set(
+        model.marginalization_cache.continuous_model_parameters
+    )
     current_idx = 1
 
     gd = model.graph_evaluation_data
@@ -281,7 +283,7 @@ function _evaluate_active_parameters_with_values!!(
         elseif !gd.is_stochastic_vals[i]
             value = node_function(evaluation_env, loop_vars)
             evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
-        elseif !gd.is_observed_vals[i] && vn in active_parameters
+        elseif !gd.is_observed_vals[i] && vn in continuous_model_parameters
             dist = node_function(evaluation_env, loop_vars)
             l = var_lengths[vn]
             value = if transformed
@@ -438,8 +440,8 @@ function _backward_sample_recursive!!(
                 memo,
                 minimal_keys,
             )
-            # The continuous-prior part of branch_prior is constant across `val` and
-            # cancels in the softmax below; the rest captures all `val`-dependent terms.
+            # Keep the full branch weight: downstream prior and likelihood terms may
+            # both depend on this candidate value.
             log_weights[k] = logpdf(dist, val) + branch_prior + branch_lik
         end
         weights = exp.(log_weights .- LogExpFunctions.logsumexp(log_weights))
@@ -910,7 +912,7 @@ function evaluate_with_marginalization_values!!(
     memo = Dict{Tuple{Int,Tuple},Tuple{T,T}}()
     sizehint!(memo, expected_entries)
 
-    evaluation_env = _evaluate_active_parameters_with_values!!(
+    evaluation_env = _evaluate_continuous_model_parameters_with_values!!(
         model, flattened_values; transformed=model.transformed
     )
 

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -131,9 +131,15 @@ function evaluate_with_env!!(
     evaluation_env=smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols);
     temperature=1.0,
     transformed=true,
+    include_generated_quantities=false,
 )
     logprior = 0.0
     loglikelihood = 0.0
+    sampled_vars = if include_generated_quantities
+        Set(model.graph_evaluation_data.sorted_parameters)
+    else
+        Set(model.graph_evaluation_data.model_parameters)
+    end
 
     for (i, vn) in enumerate(model.graph_evaluation_data.sorted_nodes)
         is_stochastic = model.graph_evaluation_data.is_stochastic_vals[i]
@@ -163,7 +169,7 @@ function evaluate_with_env!!(
 
             if is_observed
                 loglikelihood += logp
-            else
+            elseif vn in sampled_vars
                 logprior += logp
             end
         end
@@ -207,6 +213,7 @@ function evaluate_with_values!!(
     end
 
     evaluation_env = smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols)
+    sampled_vars = Set(model.graph_evaluation_data.model_parameters)
     current_idx = 1
     logprior, loglikelihood = 0.0, 0.0
     for (i, vn) in enumerate(model.graph_evaluation_data.sorted_nodes)
@@ -219,7 +226,7 @@ function evaluate_with_values!!(
             evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
         else
             dist = node_function(evaluation_env, loop_vars)
-            if !is_observed
+            if !is_observed && vn in sampled_vars
                 l = var_lengths[vn]
                 if transformed
                     b = Bijectors.bijector(dist)
@@ -240,6 +247,11 @@ function evaluate_with_values!!(
                 end
                 current_idx += l
                 logprior += logpdf(dist, value) + logjac
+                evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
+            elseif !is_observed
+                # Postprocessed stochastic variables are not part of parameter vectors
+                # and should not contribute to the sampled target density.
+                value = AbstractPPL.getvalue(evaluation_env, vn)
                 evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
             else
                 loglikelihood += logpdf(dist, AbstractPPL.getvalue(evaluation_env, vn))

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -274,6 +274,13 @@ ones are recomputed. Model parameters, observations, and transformed parameters 
 untouched. Nodes are visited in topological order, so chains of generated quantities are
 sampled with their parents already in place.
 
+If `model` is in `UseAutoMarginalization` mode its discrete latents were summed out of the
+log density and have no value in `evaluation_env`. A generated quantity may depend on such a
+latent (directly or indirectly), so before forward-sampling, the marginalized discrete
+latents are first recovered by sampling from their conditional posterior
+`p(z | θ, y)` (see [`_sample_discrete_latents!!`](@ref)). Generated quantities with no
+marginalized-discrete ancestor are unaffected by this step.
+
 This is the post-processing step that turns a posterior draw of the model parameters into a
 joint posterior(-predictive) draw that also includes the generated quantities.
 
@@ -285,6 +292,12 @@ function forward_sample_generated_quantities!!(
     model::BUGSModel,
     evaluation_env=smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols),
 )
+    # Under marginalization the discrete latents were summed out and carry no value, so
+    # recover them from their conditional posterior before any generated quantity that
+    # depends on them is forward-sampled.
+    if model.evaluation_mode isa UseAutoMarginalization
+        evaluation_env = _sample_discrete_latents!!(rng, model, evaluation_env)
+    end
     gd = model.graph_evaluation_data
     for (i, vn) in enumerate(gd.sorted_nodes)
         gd.variable_types[i] == GeneratedQuantity || continue
@@ -298,6 +311,118 @@ function forward_sample_generated_quantities!!(
         evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
     end
     return evaluation_env
+end
+
+"""
+    _sample_discrete_latents!!(rng, model, evaluation_env)
+
+Recover the marginalized discrete latents of an `UseAutoMarginalization` model by sampling
+them from their conditional posterior `p(z | θ, y)`, given an environment that already holds
+the continuous parameters and observations.
+
+The latents are drawn in the marginalization order: each discrete latent `z_i` is sampled
+from the weights `p(z_i = v | pa) · p(y, z_{>i} | z_i = v, …)`, where the second factor is
+the marginalized joint of everything downstream (computed by [`_marginalize_recursive`](@ref)
+with `z_i` fixed to `v` and the not-yet-sampled latents summed out). Normalizing over `v`
+gives exactly `p(z_i = v | z_{<i}, θ, y)`, so sampling the latents sequentially in
+topological order yields a draw from the joint posterior `p(z | θ, y)`. Continuous parameters
+are taken from `evaluation_env`; generated quantities are skipped (they are forward-sampled
+separately).
+"""
+function _sample_discrete_latents!!(
+    rng::Random.AbstractRNG, model::BUGSModel, evaluation_env
+)
+    mc = model.marginalization_cache
+    (mc === nothing || mc.n_discrete_finite == 0) && return evaluation_env
+    # Continuous parameters in the order/offsets expected by `_marginalize_recursive`.
+    param_values = getparams(model, evaluation_env)
+    return _backward_sample_recursive!!(
+        rng,
+        model,
+        evaluation_env,
+        mc.marginalization_order,
+        param_values,
+        mc.param_offsets,
+        mc.param_lengths,
+        mc.minimal_cache_keys,
+    )
+end
+
+function _backward_sample_recursive!!(
+    rng::Random.AbstractRNG,
+    model::BUGSModel,
+    env::NamedTuple,
+    remaining_indices::AbstractVector{Int},
+    param_values::AbstractVector,
+    param_offsets::Dict{<:VarName,Int},
+    var_lengths::Dict{<:VarName,Int},
+    minimal_keys::Dict{Int,Vector{Int}},
+)
+    isempty(remaining_indices) && return env
+
+    gd = model.graph_evaluation_data
+    mc = model.marginalization_cache
+
+    current_idx = remaining_indices[1]
+    current_vn = gd.sorted_nodes[current_idx]
+    rest_indices = @view(remaining_indices[2:end])
+    node_function = gd.node_function_vals[current_idx]
+    loop_vars = gd.loop_vars_vals[current_idx]
+
+    if gd.variable_types[current_idx] == GeneratedQuantity
+        # Generated quantities are forward-sampled separately; skip here.
+    elseif !gd.is_stochastic_vals[current_idx]
+        env = BangBang.setindex!!(env, node_function(env, loop_vars), current_vn)
+    elseif gd.is_observed_vals[current_idx]
+        # Observed value is already in the environment.
+    elseif mc.node_types[current_idx] == :discrete_finite
+        # Sample this latent from p(z_i = v | z_{<i}, θ, y), with z_{>i} marginalized.
+        dist = node_function(env, loop_vars)
+        possible_values = collect(_enumerate_discrete_values(dist))
+        log_weights = Vector{Float64}(undef, length(possible_values))
+        for (k, val) in enumerate(possible_values)
+            branch_env = BangBang.setindex!!(env, val, current_vn)
+            memo = Dict{Tuple{Int,Tuple},Tuple{Float64,Float64}}()
+            branch_prior, branch_lik = _marginalize_recursive(
+                model,
+                branch_env,
+                rest_indices,
+                param_values,
+                param_offsets,
+                var_lengths,
+                memo,
+                minimal_keys,
+            )
+            # The continuous-prior part of branch_prior is constant across `val` and
+            # cancels in the softmax below; the rest captures all `val`-dependent terms.
+            log_weights[k] = logpdf(dist, val) + branch_prior + branch_lik
+        end
+        weights = exp.(log_weights .- LogExpFunctions.logsumexp(log_weights))
+        sampled = possible_values[rand(rng, Distributions.Categorical(weights))]
+        env = BangBang.setindex!!(env, sampled, current_vn)
+    else
+        # Continuous (or discrete-infinite) parameter: set its value from the vector.
+        dist = node_function(env, loop_vars)
+        b_inv = Bijectors.inverse(Bijectors.bijector(dist))
+        len = var_lengths[current_vn]
+        start_idx = param_offsets[current_vn]
+        param_slice = view(param_values, start_idx:(start_idx + len - 1))
+        value, _ = Bijectors.with_logabsdet_jacobian(
+            b_inv, reconstruct(b_inv, dist, param_slice)
+        )
+        env = BangBang.setindex!!(env, value, current_vn)
+    end
+
+    return _backward_sample_recursive!!(
+        rng,
+        model,
+        env,
+        rest_indices,
+        param_values,
+        param_offsets,
+        var_lengths,
+        minimal_keys,
+    )
 end
 
 # ======================
@@ -577,7 +702,23 @@ function _marginalize_recursive(
     loop_vars = gd.loop_vars_vals[current_idx]
     rest_indices = @view(remaining_indices[2:end])
 
-    result = if !gd.is_stochastic_vals[current_idx]
+    result = if gd.variable_types[current_idx] == GeneratedQuantity
+        # Generated quantities have no observed descendants, so the whole generated-quantity
+        # block integrates/sums to one and factors out of the marginalized target p(θ, y).
+        # Skip it entirely: don't read the parameter vector (it has no slot there) and don't
+        # marginalize it. They are recovered later by forward sampling, not here.
+        _marginalize_recursive(
+            model,
+            env,
+            rest_indices,
+            parameter_values,
+            param_offsets,
+            var_lengths,
+            memo,
+            minimal_keys,
+        )
+
+    elseif !gd.is_stochastic_vals[current_idx]
         # Deterministic node: compute value and continue
         value = node_function(env, loop_vars)
         new_env = BangBang.setindex!!(env, value, current_vn)

--- a/JuliaBUGS/src/model/logdensityproblems.jl
+++ b/JuliaBUGS/src/model/logdensityproblems.jl
@@ -31,18 +31,27 @@ function LogDensityProblems.logdensity(model::BUGSModel, x::AbstractArray)
 end
 
 function LogDensityProblems.dimension(model::BUGSModel)
-    param_vars = _active_parameters(model)
-    dim = 0
-    if model.transformed
-        for vn in param_vars
-            dim += model.transformed_var_lengths[vn]
+    # Auto-marginalization needs the continuous-only filter; other modes can use the
+    # precomputed parameter lengths (already accumulated over `model_parameters`).
+    if model.evaluation_mode isa UseAutoMarginalization
+        param_vars = _active_parameters(model)
+        dim = 0
+        if model.transformed
+            for vn in param_vars
+                dim += model.transformed_var_lengths[vn]
+            end
+        else
+            for vn in param_vars
+                dim += model.untransformed_var_lengths[vn]
+            end
         end
-    else
-        for vn in param_vars
-            dim += model.untransformed_var_lengths[vn]
-        end
+        return dim
     end
-    return dim
+    return if model.transformed
+        model.transformed_param_length
+    else
+        model.untransformed_param_length
+    end
 end
 
 function LogDensityProblems.capabilities(::AbstractBUGSModel)

--- a/JuliaBUGS/src/model/logdensityproblems.jl
+++ b/JuliaBUGS/src/model/logdensityproblems.jl
@@ -30,7 +30,7 @@ function LogDensityProblems.dimension(model::BUGSModel)
     # Auto-marginalization needs the continuous-only filter; other modes can use the
     # precomputed parameter lengths (already accumulated over `model_parameters`).
     if model.evaluation_mode isa UseAutoMarginalization
-        param_vars = _active_parameters(model)
+        param_vars = model.marginalization_cache.continuous_model_parameters
         dim = 0
         if model.transformed
             for vn in param_vars

--- a/JuliaBUGS/src/model/logdensityproblems.jl
+++ b/JuliaBUGS/src/model/logdensityproblems.jl
@@ -1,10 +1,6 @@
 using LogDensityProblems
 
 function _eval_logdensity(model, ::UseGeneratedLogDensityFunction, x)
-    if !isempty(model.graph_evaluation_data.generated_quantities)
-        _, log_densities = evaluate_with_values!!(model, x; transformed=model.transformed)
-        return log_densities.tempered_logjoint
-    end
     return Base.invokelatest(
         model.log_density_computation_function, model.evaluation_env, x
     )

--- a/JuliaBUGS/src/model/logdensityproblems.jl
+++ b/JuliaBUGS/src/model/logdensityproblems.jl
@@ -1,6 +1,10 @@
 using LogDensityProblems
 
 function _eval_logdensity(model, ::UseGeneratedLogDensityFunction, x)
+    if !isempty(model.graph_evaluation_data.generated_quantities)
+        _, log_densities = evaluate_with_values!!(model, x; transformed=model.transformed)
+        return log_densities.tempered_logjoint
+    end
     return Base.invokelatest(
         model.log_density_computation_function, model.evaluation_env, x
     )
@@ -27,37 +31,18 @@ function LogDensityProblems.logdensity(model::BUGSModel, x::AbstractArray)
 end
 
 function LogDensityProblems.dimension(model::BUGSModel)
-    # For auto marginalization, only count continuous parameters
-    if model.evaluation_mode isa UseAutoMarginalization
-        mc = model.marginalization_cache
-        continuous_param_length = 0
-        for (i, vn) in enumerate(model.graph_evaluation_data.sorted_parameters)
-            idx = findfirst(==(vn), model.graph_evaluation_data.sorted_nodes)
-            if idx !== nothing
-                node_type = mc.node_types[idx]
-                # Only include continuous variables (exclude all discrete)
-                if node_type == :continuous
-                    if model.transformed
-                        continuous_param_length += model.transformed_var_lengths[vn]
-                    else
-                        continuous_param_length += model.untransformed_var_lengths[vn]
-                    end
-                elseif node_type == :discrete_infinite
-                    error(
-                        "Model contains discrete infinite variable $(vn) which cannot be marginalized. " *
-                        "Use UseGraph evaluation mode instead.",
-                    )
-                end
-            end
+    param_vars = _active_parameters(model)
+    dim = 0
+    if model.transformed
+        for vn in param_vars
+            dim += model.transformed_var_lengths[vn]
         end
-        return continuous_param_length
     else
-        return if model.transformed
-            model.transformed_param_length
-        else
-            model.untransformed_param_length
+        for vn in param_vars
+            dim += model.untransformed_var_lengths[vn]
         end
     end
+    return dim
 end
 
 function LogDensityProblems.capabilities(::AbstractBUGSModel)

--- a/JuliaBUGS/src/model/to_distribution.jl
+++ b/JuliaBUGS/src/model/to_distribution.jl
@@ -164,7 +164,12 @@ function Distributions.logpdf(d::BUGSModelDistribution, x::NamedTuple)
         )
         env = BangBang.setindex!!(env, AbstractPPL.getvalue(x, vn), vn)
     end
-    _, log_densities = evaluate_with_env!!(model, env; transformed=false)
+    # `parameters` spans all unobserved stochastic nodes (model parameters and stochastic
+    # generated quantities), so the joint must score every one of them — include the
+    # generated-quantity priors that the evaluation otherwise drops by default.
+    _, log_densities = evaluate_with_env!!(
+        model, env; transformed=false, include_generated_quantities=true
+    )
     # Untempered joint = logprior + loglikelihood, independent of any temperature default.
     return log_densities.logprior + log_densities.loglikelihood
 end

--- a/JuliaBUGS/src/model/utils.jl
+++ b/JuliaBUGS/src/model/utils.jl
@@ -113,8 +113,13 @@ function get_mutable_symbols(data)
 
     mutable_syms = Set{Symbol}()
 
-    # Add symbols from model parameters (stochastic, non-observed nodes)
-    for vn in graph_data.sorted_parameters
+    # Add symbols from sampled model parameters (stochastic, non-observed nodes).
+    for vn in graph_data.model_parameters
+        push!(mutable_syms, AbstractPPL.getsym(vn))
+    end
+
+    # Add symbols from generated quantities (forward-sampled during post-processing)
+    for vn in graph_data.generated_quantities
         push!(mutable_syms, AbstractPPL.getsym(vn))
     end
 

--- a/JuliaBUGS/src/source_gen.jl
+++ b/JuliaBUGS/src/source_gen.jl
@@ -259,29 +259,40 @@ function _lower_model_def_to_represent_observe_stmts(
             _contains_generated_quantity = !isempty(generated_quantity_loop_vars)
 
             if _contains_generated_quantity
-                # Generated-quantity iterations are forward-sampled in post-processing and
-                # must not enter the log density. Emit code only for the model-parameter,
-                # observed, and kept-deterministic iterations; generated-quantity
-                # iterations fall through. A statement that is entirely generated
-                # quantities is dropped.
+                # Generated quantities are outside the target closure. Lower only the
+                # iterations that contribute to, or are needed by, the log density.
                 new_stmt = __lower_stmt_with_generated_quantities(
                     statement,
                     observed_loop_vars,
                     model_parameter_loop_vars,
+                    generated_quantity_loop_vars,
                     deterministic_loop_vars,
                 )
                 isnothing(new_stmt) || push!(lowered_model_def.args, new_stmt)
             elseif _contains_observed
                 if _contains_model_parameter
                     MacroTools.@capture(statement, lhs_ ~ rhs_)
-                    new_stmt = MacroTools.@q if condition_placeholder
-                        $(lhs) ~ $(rhs)
+                    tilde_stmt = MacroTools.@q $(lhs) ~ $(rhs)
+                    observe_stmt = MacroTools.@q $(lhs) ≂ $(rhs)
+                    # Use the shorter condition; the complementary iterations take the
+                    # else branch while loop order preserves parameter consumption.
+                    if length(observed_loop_vars) < length(model_parameter_loop_vars)
+                        new_stmt = Expr(
+                            :if,
+                            __generate_model_parameter_condition_expr(observed_loop_vars),
+                            Expr(:block, observe_stmt),
+                            Expr(:block, tilde_stmt),
+                        )
                     else
-                        $(lhs) ≂ $(rhs)
+                        new_stmt = Expr(
+                            :if,
+                            __generate_model_parameter_condition_expr(
+                                model_parameter_loop_vars
+                            ),
+                            Expr(:block, tilde_stmt),
+                            Expr(:block, observe_stmt),
+                        )
                     end
-                    new_stmt.args[1] = __generate_model_parameter_condition_expr(
-                        model_parameter_loop_vars
-                    )
                     push!(lowered_model_def.args, new_stmt)
                 else
                     MacroTools.@capture(statement, lhs_ ~ rhs_)
@@ -344,13 +355,24 @@ function __generate_model_parameter_condition_expr(model_param_nt_vec)
     end
 end
 
-# Lower a statement that has generated-quantity iterations. Generated quantities never
-# contribute to the log density (stochastic ones are forward-sampled, deterministic ones
-# recomputed, in post-processing), so the emitted code guards the surviving categories
-# with explicit per-iteration conditions and lets generated-quantity iterations fall
-# through. Returns `nothing` when the whole statement is generated quantities.
+# Build a guard for `keep` iterations while keeping the emitted boolean expression short.
+# If the dropped set is smaller, guard on it and negate the condition.
+function __select_keep_condition(keep_loop_vars, drop_loop_vars)
+    if !isempty(drop_loop_vars) && length(drop_loop_vars) < length(keep_loop_vars)
+        return Expr(:call, :!, __generate_model_parameter_condition_expr(drop_loop_vars))
+    else
+        return __generate_model_parameter_condition_expr(keep_loop_vars)
+    end
+end
+
+# Lower a statement with generated-quantity iterations. Generated quantities are omitted
+# from the target; remaining iterations are guarded by loop index as needed.
 function __lower_stmt_with_generated_quantities(
-    statement, observed_loop_vars, model_parameter_loop_vars, deterministic_loop_vars
+    statement,
+    observed_loop_vars,
+    model_parameter_loop_vars,
+    generated_quantity_loop_vars,
+    deterministic_loop_vars,
 )
     if Meta.isexpr(statement, :call)
         # Stochastic `~` statement: keep model-parameter (`~`) and observed (`≂`) iterations.
@@ -360,6 +382,7 @@ function __lower_stmt_with_generated_quantities(
         tilde_stmt = MacroTools.@q $(lhs) ~ $(rhs)
         observe_stmt = MacroTools.@q $(lhs) ≂ $(rhs)
         if has_model_parameter && has_observed
+            # Omit the generated-quantity iterations by leaving no final else branch.
             return Expr(
                 :if,
                 __generate_model_parameter_condition_expr(model_parameter_loop_vars),
@@ -371,31 +394,41 @@ function __lower_stmt_with_generated_quantities(
                 ),
             )
         elseif has_model_parameter
+            # Keep `~` only where the variable remains a model parameter.
             return Expr(
                 :if,
-                __generate_model_parameter_condition_expr(model_parameter_loop_vars),
+                __select_keep_condition(
+                    model_parameter_loop_vars, generated_quantity_loop_vars
+                ),
                 Expr(:block, tilde_stmt),
             )
         elseif has_observed
+            # Keep `≂` only where the variable is observed.
             return Expr(
                 :if,
-                __generate_model_parameter_condition_expr(observed_loop_vars),
+                __select_keep_condition(observed_loop_vars, generated_quantity_loop_vars),
                 Expr(:block, observe_stmt),
             )
         else
             return nothing
         end
     else
-        # Deterministic `=` statement: keep the iterations that feed observations
-        # (transformed parameters); drop the generated-quantity ones.
+        # Deterministic generated quantities may be recomputed here because their values
+        # do not affect the target. Avoid the branch when dropped iterations are few;
+        # otherwise guard the kept deterministic iterations.
         if isempty(deterministic_loop_vars)
             return nothing
+        elseif length(generated_quantity_loop_vars) <= length(deterministic_loop_vars)
+            return statement
+        else
+            return Expr(
+                :if,
+                __select_keep_condition(
+                    deterministic_loop_vars, generated_quantity_loop_vars
+                ),
+                Expr(:block, statement),
+            )
         end
-        return Expr(
-            :if,
-            __generate_model_parameter_condition_expr(deterministic_loop_vars),
-            Expr(:block, statement),
-        )
     end
 end
 

--- a/JuliaBUGS/src/source_gen.jl
+++ b/JuliaBUGS/src/source_gen.jl
@@ -252,12 +252,26 @@ function _lower_model_def_to_represent_observe_stmts(
     for statement in reconstructed_model_def.args
         if Meta.isexpr(statement, (:(=), :call))
             stmt_id = stmt_to_stmt_id[statement]
-            observed_loop_vars, model_parameter_loop_vars, deterministic_loop_vars = var_types[stmt_id]
+            observed_loop_vars, model_parameter_loop_vars, generated_quantity_loop_vars, deterministic_loop_vars = var_types[stmt_id]
 
             _contains_observed = !isempty(observed_loop_vars)
             _contains_model_parameter = !isempty(model_parameter_loop_vars)
+            _contains_generated_quantity = !isempty(generated_quantity_loop_vars)
 
-            if _contains_observed
+            if _contains_generated_quantity
+                # Generated-quantity iterations are forward-sampled in post-processing and
+                # must not enter the log density. Emit code only for the model-parameter,
+                # observed, and kept-deterministic iterations; generated-quantity
+                # iterations fall through. A statement that is entirely generated
+                # quantities is dropped.
+                new_stmt = __lower_stmt_with_generated_quantities(
+                    statement,
+                    observed_loop_vars,
+                    model_parameter_loop_vars,
+                    deterministic_loop_vars,
+                )
+                isnothing(new_stmt) || push!(lowered_model_def.args, new_stmt)
+            elseif _contains_observed
                 if _contains_model_parameter
                     MacroTools.@capture(statement, lhs_ ~ rhs_)
                     new_stmt = MacroTools.@q if condition_placeholder
@@ -330,6 +344,61 @@ function __generate_model_parameter_condition_expr(model_param_nt_vec)
     end
 end
 
+# Lower a statement that has generated-quantity iterations. Generated quantities never
+# contribute to the log density (stochastic ones are forward-sampled, deterministic ones
+# recomputed, in post-processing), so the emitted code guards the surviving categories
+# with explicit per-iteration conditions and lets generated-quantity iterations fall
+# through. Returns `nothing` when the whole statement is generated quantities.
+function __lower_stmt_with_generated_quantities(
+    statement, observed_loop_vars, model_parameter_loop_vars, deterministic_loop_vars
+)
+    if Meta.isexpr(statement, :call)
+        # Stochastic `~` statement: keep model-parameter (`~`) and observed (`≂`) iterations.
+        MacroTools.@capture(statement, lhs_ ~ rhs_)
+        has_model_parameter = !isempty(model_parameter_loop_vars)
+        has_observed = !isempty(observed_loop_vars)
+        tilde_stmt = MacroTools.@q $(lhs) ~ $(rhs)
+        observe_stmt = MacroTools.@q $(lhs) ≂ $(rhs)
+        if has_model_parameter && has_observed
+            return Expr(
+                :if,
+                __generate_model_parameter_condition_expr(model_parameter_loop_vars),
+                Expr(:block, tilde_stmt),
+                Expr(
+                    :elseif,
+                    __generate_model_parameter_condition_expr(observed_loop_vars),
+                    Expr(:block, observe_stmt),
+                ),
+            )
+        elseif has_model_parameter
+            return Expr(
+                :if,
+                __generate_model_parameter_condition_expr(model_parameter_loop_vars),
+                Expr(:block, tilde_stmt),
+            )
+        elseif has_observed
+            return Expr(
+                :if,
+                __generate_model_parameter_condition_expr(observed_loop_vars),
+                Expr(:block, observe_stmt),
+            )
+        else
+            return nothing
+        end
+    else
+        # Deterministic `=` statement: keep the iterations that feed observations
+        # (transformed parameters); drop the generated-quantity ones.
+        if isempty(deterministic_loop_vars)
+            return nothing
+        end
+        return Expr(
+            :if,
+            __generate_model_parameter_condition_expr(deterministic_loop_vars),
+            Expr(:block, statement),
+        )
+    end
+end
+
 function __check_for_reserved_names(model_def::Expr)
     variable_names_and_numdims = JuliaBUGS.extract_variable_names_and_numdims(model_def)
     variable_names = keys(variable_names_and_numdims)
@@ -355,6 +424,7 @@ function _generate_lowered_model_def(
     g::JuliaBUGS.BUGSGraph,
     evaluation_env::NamedTuple;
     diagnostics::Vector{String}=String[],
+    generated_quantities::Set{<:VarName}=Set{VarName}(),
 )
     __check_for_reserved_names(model_def)
     stmt_to_stmt_id = _build_stmt_to_stmt_id(model_def)
@@ -419,7 +489,7 @@ function _generate_lowered_model_def(
     )
     induction_variable_values = _var_to_loop_vars(model_def, evaluation_env)
     var_types = __determine_var_types(
-        g, stmt_id_to_var, stmt_id_to_stmt, induction_variable_values
+        g, stmt_id_to_var, stmt_id_to_stmt, induction_variable_values, generated_quantities
     )
     lowered_model_def = _lower_model_def_to_represent_observe_stmts(
         reconstructed_model_def, stmt_to_stmt_id, var_types, evaluation_env
@@ -492,36 +562,45 @@ function _var_to_loop_vars(model_def, evaluation_env)
 end
 
 function __determine_var_types(
-    g::JuliaBUGS.BUGSGraph, stmt_id_to_var, stmt_id_to_stmt, induction_variable_values
+    g::JuliaBUGS.BUGSGraph,
+    stmt_id_to_var,
+    stmt_id_to_stmt,
+    induction_variable_values,
+    generated_quantities,
 )
-    # for each statement, have three list to collect the var of each type
-    var_types = [([], [], []) for _ in 1:length(stmt_id_to_stmt)]
+    # For each statement, collect the loop-variable values of each variable category:
+    # (observed, model_parameter, generated_quantity, deterministic).
+    var_types = [([], [], [], []) for _ in 1:length(stmt_id_to_stmt)]
     for stmt_id in keys(stmt_id_to_stmt)
         if !haskey(stmt_id_to_var, stmt_id)
             continue
         end
         vars = stmt_id_to_var[stmt_id]
         for var in vars
-            var_type = __variable_type(g, var)
+            var_type = __variable_type(g, var, generated_quantities)
             if var_type == :observed
                 push!(var_types[stmt_id][1], induction_variable_values[var])
             elseif var_type == :model_parameter
                 push!(var_types[stmt_id][2], induction_variable_values[var])
-            else
+            elseif var_type == :generated_quantity
                 push!(var_types[stmt_id][3], induction_variable_values[var])
+            else
+                push!(var_types[stmt_id][4], induction_variable_values[var])
             end
         end
     end
     return var_types
 end
 
-function __variable_type(g::JuliaBUGS.BUGSGraph, var)
-    if g[var].is_stochastic
-        if g[var].is_observed
-            return :observed
-        else
-            return :model_parameter
-        end
+function __variable_type(g::JuliaBUGS.BUGSGraph, var, generated_quantities)
+    if g[var].is_stochastic && g[var].is_observed
+        return :observed
+    elseif var in generated_quantities
+        # No observed descendants: stochastic ones are forward-sampled and deterministic
+        # ones are recomputed in post-processing, so neither belongs in the log density.
+        return :generated_quantity
+    elseif g[var].is_stochastic
+        return :model_parameter
     else
         return :deterministic
     end

--- a/JuliaBUGS/src/source_gen.jl
+++ b/JuliaBUGS/src/source_gen.jl
@@ -424,7 +424,7 @@ function _generate_lowered_model_def(
     g::JuliaBUGS.BUGSGraph,
     evaluation_env::NamedTuple;
     diagnostics::Vector{String}=String[],
-    generated_quantities::Set{<:VarName}=Set{VarName}(),
+    generated_quantities::Union{Nothing,Set{<:VarName}}=nothing,
 )
     __check_for_reserved_names(model_def)
     stmt_to_stmt_id = _build_stmt_to_stmt_id(model_def)
@@ -488,8 +488,17 @@ function _generate_lowered_model_def(
         sorted_fissioned_stmts
     )
     induction_variable_values = _var_to_loop_vars(model_def, evaluation_env)
+    generated_quantity_vars = if generated_quantities === nothing
+        Set(Model.GraphEvaluationData(g).generated_quantities)
+    else
+        generated_quantities
+    end
     var_types = __determine_var_types(
-        g, stmt_id_to_var, stmt_id_to_stmt, induction_variable_values, generated_quantities
+        g,
+        stmt_id_to_var,
+        stmt_id_to_stmt,
+        induction_variable_values,
+        generated_quantity_vars,
     )
     lowered_model_def = _lower_model_def_to_represent_observe_stmts(
         reconstructed_model_def, stmt_to_stmt_id, var_types, evaluation_env
@@ -596,8 +605,9 @@ function __variable_type(g::JuliaBUGS.BUGSGraph, var, generated_quantities)
     if g[var].is_stochastic && g[var].is_observed
         return :observed
     elseif var in generated_quantities
-        # No observed descendants: stochastic ones are forward-sampled and deterministic
-        # ones are recomputed in post-processing, so neither belongs in the log density.
+        # Outside the target closure: stochastic ones are forward-sampled and
+        # deterministic ones are recomputed in post-processing, so neither belongs in
+        # the log density.
         return :generated_quantity
     elseif g[var].is_stochastic
         return :model_parameter

--- a/JuliaBUGS/test/ad_compatibility.jl
+++ b/JuliaBUGS/test/ad_compatibility.jl
@@ -116,9 +116,10 @@
         x = JuliaBUGS.getparams(model)
 
         @testset "AutoReverseDiff - should warn and switch to UseGraph" begin
-            grad_model = @test_warn "does not support mutation" JuliaBUGS.BUGSModelWithGradient(
-                model, AutoReverseDiff()
-            )
+            # Note: The warning uses maxlog=1, so it may be suppressed if another
+            # test in the suite triggered it first. We only assert the behavioral
+            # invariant (mode switches to UseGraph).
+            grad_model = JuliaBUGS.BUGSModelWithGradient(model, AutoReverseDiff())
             @test grad_model.base_model.evaluation_mode isa JuliaBUGS.UseGraph
 
             # Should still work after switching

--- a/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
@@ -162,3 +162,34 @@ end
     # Model-parameter column matches the synthetic samples in order.
     @test mucol ≈ [s[1] for s in samples]
 end
+
+@testset "auto-marginalized chains reconstruct generated quantities from samples" begin
+    model_def = @bugs begin
+        mu ~ Normal(0, 1)
+        z ~ Categorical(w[1:2])
+        y ~ Normal(mu + z, 1)
+        pred = mu + 1.0
+    end
+
+    model = compile(model_def, (; w=[0.5, 0.5], y=1.0))
+    model = JuliaBUGS.settrans(model, true)
+    model = JuliaBUGS.set_evaluation_mode(model, JuliaBUGS.UseAutoMarginalization())
+    @test LogDensityProblems.dimension(model) == 1
+
+    samples = [[m] for m in range(-1.0, 1.0; length=25)]
+    chn = JuliaBUGS.gen_chains(model, samples, Symbol[], []; rng=StableRNG(2024))
+
+    colnames = names(chn)
+    @test :mu in colnames
+    @test :z in colnames       # recovered marginalized latent
+    @test :pred in colnames    # deterministic generated quantity
+
+    A = Array(chn)
+    mucol = A[:, findfirst(==(:mu), colnames)]
+    zcol = A[:, findfirst(==(:z), colnames)]
+    predcol = A[:, findfirst(==(:pred), colnames)]
+
+    @test mucol ≈ [s[1] for s in samples]
+    @test predcol ≈ mucol .+ 1.0
+    @test all(z -> z in (1, 2), zcol)
+end

--- a/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
@@ -164,10 +164,10 @@ end
 end
 
 @testset "chains use cached generated-quantity classification" begin
-    # Even without any observations, a deterministic node has no observed descendants
-    # and is therefore a generated quantity; the stochastic node remains a model
+    # Even without any observations, a terminal deterministic node that feeds no
+    # stochastic factor is a generated quantity; the stochastic node remains a model
     # parameter. `gen_chains` reads the cached classification, so this guards against
-    # the cached generated-quantity set dropping deterministic nodes.
+    # the cached generated-quantity set dropping terminal deterministic nodes.
     model_def = @bugs begin
         x ~ dnorm(0, 1)
         pred = x + 1.0

--- a/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
@@ -130,3 +130,35 @@
         Symbol("A[1, 1:3][3]"),
     ])
 end
+
+@testset "forward-sampled generated quantities in chains" begin
+    model_def = @bugs begin
+        mu ~ dnorm(0, 1)
+        y ~ dnorm(mu, 1)
+        z ~ dnorm(mu, 1)      # stochastic generated quantity
+        pred = mu + 1.0       # deterministic generated quantity
+    end
+    model = compile(model_def, (; y=0.5))
+    @test LogDensityProblems.dimension(model) == 1
+
+    # Synthetic posterior draws of the single model parameter `mu`.
+    samples = [[m] for m in range(-1.0, 1.0; length=25)]
+    chn = JuliaBUGS.gen_chains(model, samples, Symbol[], []; rng=StableRNG(2024))
+
+    colnames = names(chn)
+    @test :mu in colnames
+    @test :z in colnames       # stochastic generated quantity surfaced
+    @test :pred in colnames    # deterministic generated quantity surfaced
+
+    A = Array(chn)
+    mucol = A[:, findfirst(==(:mu), colnames)]
+    zcol = A[:, findfirst(==(:z), colnames)]
+    predcol = A[:, findfirst(==(:pred), colnames)]
+
+    # Stochastic generated quantity is forward-sampled, not frozen at one value.
+    @test length(unique(zcol)) > 1
+    # Deterministic generated quantity equals f(model parameter) for every draw.
+    @test all(predcol .≈ mucol .+ 1.0)
+    # Model-parameter column matches the synthetic samples in order.
+    @test mucol ≈ [s[1] for s in samples]
+end

--- a/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
@@ -163,6 +163,27 @@ end
     @test mucol ≈ [s[1] for s in samples]
 end
 
+@testset "chains use cached generated-quantity classification" begin
+    # Even without any observations, a deterministic node has no observed descendants
+    # and is therefore a generated quantity; the stochastic node remains a model
+    # parameter. `gen_chains` reads the cached classification, so this guards against
+    # the cached generated-quantity set dropping deterministic nodes.
+    model_def = @bugs begin
+        x ~ dnorm(0, 1)
+        pred = x + 1.0
+    end
+    model = compile(model_def, (;))
+
+    @test !isempty(JuliaBUGS.Model.generated_quantities(model))
+
+    samples = [[-0.5], [0.5]]
+    chn = JuliaBUGS.gen_chains(model, samples, Symbol[], []; rng=StableRNG(2024))
+
+    colnames = names(chn)
+    @test :x in colnames
+    @test :pred in colnames
+end
+
 @testset "auto-marginalized chains reconstruct generated quantities from samples" begin
     model_def = @bugs begin
         mu ~ Normal(0, 1)

--- a/JuliaBUGS/test/gibbs.jl
+++ b/JuliaBUGS/test/gibbs.jl
@@ -507,9 +507,10 @@ using StatsBase: mode
         model = compile(model_def, (; J=J, N=N, group_id=group_id, y=y_data))
 
         @testset "Complex model sampler map" begin
+            # α and β are generated quantities (unused in the likelihood) and are
+            # correctly excluded from model_parameters, so they don't need samplers.
             # Test various ways to specify the sampler map
             sampler_map1 = OrderedDict(
-                [@varname(α), @varname(β)] => IndependentMH(),
                 @varname(μ) => IndependentMH(),
                 @varname(θ) => IndependentMH(),
             )
@@ -517,8 +518,6 @@ using StatsBase: mode
 
             # More granular specification
             sampler_map2 = OrderedDict(
-                @varname(α) => IndependentMH(),
-                @varname(β) => IndependentMH(),
                 [@varname(μ[1]), @varname(μ[2]), @varname(μ[3])] => IndependentMH(),
                 [@varname(θ[i]) for i in 1:N] => IndependentMH(),
             )

--- a/JuliaBUGS/test/gibbs.jl
+++ b/JuliaBUGS/test/gibbs.jl
@@ -511,8 +511,7 @@ using StatsBase: mode
             # correctly excluded from model_parameters, so they don't need samplers.
             # Test various ways to specify the sampler map
             sampler_map1 = OrderedDict(
-                @varname(μ) => IndependentMH(),
-                @varname(θ) => IndependentMH(),
+                @varname(μ) => IndependentMH(), @varname(θ) => IndependentMH()
             )
             @test verify_sampler_map(model, sampler_map1)
 

--- a/JuliaBUGS/test/model/abstractmcmc.jl
+++ b/JuliaBUGS/test/model/abstractmcmc.jl
@@ -81,4 +81,32 @@ using Test
         @test length(collected) == 3
         @test all(c -> haskey(c, :mu), collected)
     end
+
+    @testset "ParamsWithStats with auto-marginalization reports flat parameters" begin
+        model_def = @bugs begin
+            mu ~ Normal(0, 1)
+            z ~ Categorical(w[1:K])
+            y ~ Normal(mu + delta[z], sigma)
+        end
+
+        model = compile(model_def, (K=2, w=[0.3, 0.7], delta=[0.0, 2.0], sigma=1.0, y=1.5))
+        model = JuliaBUGS.settrans(model, true)
+        model = JuliaBUGS.set_evaluation_mode(model, JuliaBUGS.UseAutoMarginalization())
+        transition, log_densities = JuliaBUGS.Model.evaluate_with_marginalization_values!!(
+            model, [0.0]
+        )
+
+        pws = AbstractMCMC.ParamsWithStats(
+            AbstractMCMC.LogDensityModel(model),
+            sampler,
+            transition,
+            state;
+            params=true,
+            stats=true,
+        )
+
+        @test haskey(pws.params, :mu)
+        @test !haskey(pws.params, :z)
+        @test pws.stats.lp ≈ log_densities.tempered_logjoint
+    end
 end

--- a/JuliaBUGS/test/model/abstractppl.jl
+++ b/JuliaBUGS/test/model/abstractppl.jl
@@ -81,7 +81,7 @@ JuliaBUGS.@bugs_primitive Normal Gamma
             @test !isnothing(model_cond_gen.log_density_computation_function)
 
             # Use zeros to avoid parameter order issues
-            params = zeros(length(parameters(model_cond)))
+            params = zeros(LogDensityProblems.dimension(model_cond))
             logp1 = Base.invokelatest(LogDensityProblems.logdensity, model_cond_gen, params)
 
             # Compare with graph evaluation on the SAME model (model_cond_gen)
@@ -221,7 +221,7 @@ JuliaBUGS.@bugs_primitive Normal Gamma
                 @test m2.evaluation_mode isa UseGraph
 
                 # Can switch to generated mode explicitly and match graph
-                params = zeros(length(parameters(m2)))
+                params = zeros(LogDensityProblems.dimension(m2))
                 logp_gen = Base.invokelatest(
                     LogDensityProblems.logdensity,
                     set_evaluation_mode(m2, UseGeneratedLogDensityFunction()),

--- a/JuliaBUGS/test/model/abstractppl.jl
+++ b/JuliaBUGS/test/model/abstractppl.jl
@@ -3,9 +3,14 @@ using JuliaBUGS
 using JuliaBUGS.Model:
     condition,
     decondition,
+    generated_quantities,
+    model_parameters,
     parameters,
     set_evaluation_mode,
     set_observed_values!,
+    variable_type,
+    ModelParameter,
+    Observation,
     regenerate_log_density_function,
     UseGeneratedLogDensityFunction,
     UseGraph
@@ -48,6 +53,38 @@ JuliaBUGS.@bugs_primitive Normal Gamma
             )
 
             @test logp1 ≈ logp2
+        end
+
+        @testset "conditioning generated quantity updates ancestor classification" begin
+            model_def = @bugs begin
+                theta ~ Normal(0, 1)
+                z ~ Normal(theta, 1)
+                y ~ Normal(0, 1)
+            end
+
+            model = compile(model_def, (; y=0.0))
+            @test isempty(model_parameters(model))
+            @test @varname(theta) in generated_quantities(model)
+            @test @varname(z) in generated_quantities(model)
+
+            conditioned_model = condition(model, Dict(@varname(z) => 0.5))
+            @test variable_type(conditioned_model, @varname(z)) == Observation
+            @test variable_type(conditioned_model, @varname(theta)) == ModelParameter
+            @test model_parameters(conditioned_model) == [@varname(theta)]
+            @test @varname(theta) ∉ generated_quantities(conditioned_model)
+            @test LogDensityProblems.dimension(conditioned_model) == 1
+
+            params = [0.25]
+            graph_logdensity = Base.invokelatest(
+                LogDensityProblems.logdensity, conditioned_model, params
+            )
+            generated_conditioned_model = set_evaluation_mode(
+                conditioned_model, UseGeneratedLogDensityFunction()
+            )
+            generated_logdensity = Base.invokelatest(
+                LogDensityProblems.logdensity, generated_conditioned_model, params
+            )
+            @test generated_logdensity ≈ graph_logdensity
         end
 
         @testset "Array model conditioning with correct parameter ordering" begin

--- a/JuliaBUGS/test/model/auto_marginalization.jl
+++ b/JuliaBUGS/test/model/auto_marginalization.jl
@@ -6,7 +6,9 @@ using JuliaBUGS.Model:
     set_evaluation_mode,
     UseAutoMarginalization,
     UseGraph,
-    evaluate_with_marginalization_values!!
+    UseGeneratedLogDensityFunction,
+    evaluate_with_marginalization_values!!,
+    forward_sample_generated_quantities!!
 
 @testset "Auto-Marginalization" begin
     # HMM helper function for ground truth using forward algorithm
@@ -848,5 +850,188 @@ using JuliaBUGS.Model:
         # Both should give same results
         @test isapprox(val_rd, val_fd; atol=1e-10)
         @test isapprox(grad_rd, grad_fd; atol=1e-8)
+    end
+
+    @testset "generated quantities are excluded from the marginalized target" begin
+        # A generated quantity has no observed descendants, so its factor
+        # integrates/sums to one and the whole generated-quantity block factors out of
+        # p(θ, y). The marginalization must skip it: not read it from the parameter
+        # vector (it has no slot there) and not marginalize it.
+
+        @testset "no discrete latents: all three modes agree" begin
+            # Regression: marginalization used to throw `KeyError: z` on a continuous
+            # generated quantity, because the marginalization order included it but the
+            # parameter offsets (built over model parameters) did not.
+            model_def = @bugs begin
+                mu ~ Normal(0, 1)
+                y ~ Normal(mu, 1)
+                z ~ Normal(mu, 1)        # continuous generated quantity
+            end
+            model = settrans(compile(model_def, (; y=0.5)), true)
+            m_graph = set_evaluation_mode(model, UseGraph())
+            m_gen = set_evaluation_mode(model, UseGeneratedLogDensityFunction())
+            m_marg = set_evaluation_mode(model, UseAutoMarginalization())
+
+            @test LogDensityProblems.dimension(m_marg) ==
+                LogDensityProblems.dimension(m_graph)
+
+            # Compare at matched parameter values (flatten in each model's own order).
+            env, _ = Base.invokelatest(AbstractPPL.evaluate!!, StableRNG(1), model)
+            lp_graph = Base.invokelatest(
+                LogDensityProblems.logdensity, m_graph, getparams(m_graph, env)
+            )
+            lp_gen = Base.invokelatest(
+                LogDensityProblems.logdensity, m_gen, getparams(m_gen, env)
+            )
+            lp_marg = Base.invokelatest(
+                LogDensityProblems.logdensity, m_marg, getparams(m_marg, env)
+            )
+            @test isapprox(lp_graph, lp_marg; atol=1e-10)
+            @test isapprox(lp_gen, lp_marg; atol=1e-10)
+        end
+
+        @testset "discrete latent + GQ: marginalized log density unchanged" begin
+            # Fixed-parameter HMM (z[1], z[2] marginalized); reference via forward
+            # algorithm. Adding a generated quantity -- including one that depends on a
+            # marginalized latent (case 3) -- must not change the marginalized target.
+            expected = forward_algorithm_hmm(
+                [0.1, 4.9], 0.0, 5.0, 1.0, [0.5, 0.5], [0.7 0.3; 0.4 0.6]
+            )
+            data = (T=2, y=[0.1, 4.9])
+
+            hmm_base = @bugs begin
+                mu[1] = 0.0
+                mu[2] = 5.0
+                sigma = 1.0
+                trans[1, 1] = 0.7
+                trans[1, 2] = 0.3
+                trans[2, 1] = 0.4
+                trans[2, 2] = 0.6
+                pi[1] = 0.5
+                pi[2] = 0.5
+                z[1] ~ Categorical(pi[1:2])
+                for t in 2:T
+                    p[t, 1] = trans[z[t - 1], 1]
+                    p[t, 2] = trans[z[t - 1], 2]
+                    z[t] ~ Categorical(p[t, :])
+                end
+                for t in 1:T
+                    y[t] ~ Normal(mu[z[t]], sigma)
+                end
+            end
+            hmm_case2 = @bugs begin
+                mu[1] = 0.0
+                mu[2] = 5.0
+                sigma = 1.0
+                trans[1, 1] = 0.7
+                trans[1, 2] = 0.3
+                trans[2, 1] = 0.4
+                trans[2, 2] = 0.6
+                pi[1] = 0.5
+                pi[2] = 0.5
+                z[1] ~ Categorical(pi[1:2])
+                for t in 2:T
+                    p[t, 1] = trans[z[t - 1], 1]
+                    p[t, 2] = trans[z[t - 1], 2]
+                    z[t] ~ Categorical(p[t, :])
+                end
+                for t in 1:T
+                    y[t] ~ Normal(mu[z[t]], sigma)
+                end
+                g ~ Normal(0, 1)            # case-2 GQ (no marginalized-discrete ancestor)
+            end
+            hmm_case3 = @bugs begin
+                mu[1] = 0.0
+                mu[2] = 5.0
+                sigma = 1.0
+                trans[1, 1] = 0.7
+                trans[1, 2] = 0.3
+                trans[2, 1] = 0.4
+                trans[2, 2] = 0.6
+                pi[1] = 0.5
+                pi[2] = 0.5
+                z[1] ~ Categorical(pi[1:2])
+                for t in 2:T
+                    p[t, 1] = trans[z[t - 1], 1]
+                    p[t, 2] = trans[z[t - 1], 2]
+                    z[t] ~ Categorical(p[t, :])
+                end
+                for t in 1:T
+                    y[t] ~ Normal(mu[z[t]], sigma)
+                end
+                g ~ Normal(mu[z[1]], 1)     # case-3 GQ (depends on marginalized z[1])
+            end
+
+            for model_def in (hmm_base, hmm_case2, hmm_case3)
+                model = set_evaluation_mode(
+                    settrans(compile(model_def, data), true), UseAutoMarginalization()
+                )
+                lp = Base.invokelatest(LogDensityProblems.logdensity, model, Float64[])
+                @test isapprox(lp, expected; atol=1e-6)
+            end
+        end
+    end
+
+    @testset "recover marginalized latents when forward-sampling GQ (case 3)" begin
+        # A generated quantity that depends on a marginalized discrete latent needs a value
+        # for that latent. `forward_sample_generated_quantities!!` recovers it by sampling
+        # from p(z | θ, y) before forward-sampling the GQ. Use a 2-state, 2-observation HMM
+        # with overlapping emissions so the posterior is spread across all states, and check
+        # the empirical distribution of the recovered (z[1], z[2]) against the analytic
+        # posterior and E[g] against the analytic mixture mean.
+        mu = [0.0, 2.0]
+        y_obs = [0.7, 1.3]
+        pivec = [0.5, 0.5]
+        trans = [0.7 0.3; 0.4 0.6]
+        W = [
+            pivec[i] *
+            pdf(Normal(mu[i], 1), y_obs[1]) *
+            trans[i, j] *
+            pdf(Normal(mu[j], 1), y_obs[2]) for i in 1:2, j in 1:2
+        ]
+        P = W ./ sum(W)               # analytic p(z[1], z[2] | y)
+        pz1 = vec(sum(P; dims=2))     # analytic p(z[1] | y)
+        Eg = sum(pz1 .* mu)           # analytic E[g] = E[mu[z[1]]]
+
+        hmm_case3 = @bugs begin
+            mu[1] = 0.0
+            mu[2] = 2.0
+            sigma = 1.0
+            trans[1, 1] = 0.7
+            trans[1, 2] = 0.3
+            trans[2, 1] = 0.4
+            trans[2, 2] = 0.6
+            pi[1] = 0.5
+            pi[2] = 0.5
+            z[1] ~ Categorical(pi[1:2])
+            for t in 2:T
+                p[t, 1] = trans[z[t - 1], 1]
+                p[t, 2] = trans[z[t - 1], 2]
+                z[t] ~ Categorical(p[t, :])
+            end
+            for t in 1:T
+                y[t] ~ Normal(mu[z[t]], sigma)
+            end
+            g ~ Normal(mu[z[1]], 1)      # case-3 GQ
+        end
+        model = set_evaluation_mode(
+            settrans(compile(hmm_case3, (T=2, y=y_obs)), true), UseAutoMarginalization()
+        )
+
+        N = 20000
+        counts = zeros(Int, 2, 2)
+        g_sum = 0.0
+        for s in 1:N
+            env = Base.invokelatest(
+                forward_sample_generated_quantities!!, StableRNG(s), model
+            )
+            z1 = Int(AbstractPPL.getvalue(env, @varname(z[1])))
+            z2 = Int(AbstractPPL.getvalue(env, @varname(z[2])))
+            counts[z1, z2] += 1
+            g_sum += AbstractPPL.getvalue(env, @varname(g))
+        end
+        P_emp = counts ./ N
+        @test maximum(abs.(P_emp .- P)) < 0.02
+        @test isapprox(g_sum / N, Eg; atol=0.05)
     end
 end

--- a/JuliaBUGS/test/model/bugsmodel.jl
+++ b/JuliaBUGS/test/model/bugsmodel.jl
@@ -205,6 +205,64 @@ end
         @test @varname(mean_x) ∉ gq
     end
 
+    @testset "MCMC partition excludes generated quantities" begin
+        # mu drives the likelihood (model parameter); z is a stochastic generated
+        # quantity (no observed descendant); pred is a deterministic generated quantity.
+        model_def = @bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            z ~ Normal(mu, 1)
+            pred = mu + 1.0
+        end
+        model = compile(model_def, (; y=0.5))
+
+        # Only the model parameter enters the MCMC parameter vector.
+        @test model_parameters(model) == [@varname(mu)]
+        @test @varname(z) in generated_quantities(model)
+        @test @varname(pred) in generated_quantities(model)
+        @test LogDensityProblems.dimension(model) == 1
+        @test length(getparams(model)) == 1
+
+        # `parameters` (all unobserved stochastic) still includes the stochastic GQ, so
+        # it now legitimately differs in length from the MCMC dimension.
+        @test @varname(z) in parameters(model)
+        @test length(parameters(model)) != LogDensityProblems.dimension(model)
+
+        # The dimension fast path agrees with the precomputed length field.
+        @test LogDensityProblems.dimension(model) == model.transformed_param_length
+
+        x = getparams(model)
+        env, logp = AbstractPPL.evaluate!!(model, x)
+        model_env = JuliaBUGS.Accessors.@set model.evaluation_env = env
+
+        # GQ-exclusion invariant: the MCMC target equals the full joint minus the
+        # generated-quantity prior terms.
+        _, ld_excl = JuliaBUGS.Model.evaluate_with_env!!(
+            model_env; transformed=model.transformed, include_generated_quantities=false
+        )
+        _, ld_incl = JuliaBUGS.Model.evaluate_with_env!!(
+            model_env; transformed=model.transformed, include_generated_quantities=true
+        )
+        z_logp = logpdf(
+            Normal(AbstractPPL.getvalue(env, @varname(mu)), 1),
+            AbstractPPL.getvalue(env, @varname(z)),
+        )
+        @test ld_incl.logprior - ld_excl.logprior ≈ z_logp
+        @test logp ≈ ld_excl.logprior + ld_excl.loglikelihood
+
+        # Regression for the env/rng acceptance inconsistency: the ancestral proposal
+        # and the env recompute use the same GQ policy, so they agree on the same env.
+        rng = StableRNG(123)
+        env_rng, ld_rng = JuliaBUGS.Model.evaluate_with_rng!!(
+            rng, model; transformed=model.transformed
+        )
+        model_rng = JuliaBUGS.Accessors.@set model.evaluation_env = env_rng
+        _, ld_rng_env = JuliaBUGS.Model.evaluate_with_env!!(
+            model_rng; transformed=model.transformed, include_generated_quantities=false
+        )
+        @test ld_rng.tempered_logjoint ≈ ld_rng_env.tempered_logjoint
+    end
+
     @testset "initialize!" begin
         model_def = @bugs begin
             a ~ Normal(0, 1)

--- a/JuliaBUGS/test/model/bugsmodel.jl
+++ b/JuliaBUGS/test/model/bugsmodel.jl
@@ -4,11 +4,19 @@ using JuliaBUGS.Model:
     decondition,
     parameters,
     variables,
+    model_parameters,
+    generated_quantities,
+    variable_type,
     getparams,
     settrans,
     set_evaluation_mode,
     UseGeneratedLogDensityFunction,
-    UseGraph
+    UseGraph,
+    VariableType,
+    Observation,
+    ModelParameter,
+    TransformedParameter,
+    GeneratedQuantity
 
 @testset "Compile Vol.1 BUGS Examples" begin
     for model_name in keys(JuliaBUGS.BUGSExamples.VOLUME_1)
@@ -84,6 +92,117 @@ end
             condition(model, Dict(@varname(x) => [1.0, 2.0, 3.0]))
         )
         @test length(parameters(model_subsume)) == 2  # Only mu and sigma remain
+    end
+
+    @testset "VariableType classification" begin
+        # Model with all four variable types
+        model_def = @bugs begin
+            mu ~ Normal(0, 10)
+            sigma ~ Gamma(1, 1)
+            for i in 1:3
+                x[i] ~ Normal(mu, sigma)
+            end
+            mean_x = mean(x[:])
+            y ~ Normal(mean_x, 1)
+        end
+
+        model = compile(model_def, (; y=2.5))
+
+        # Test variable_type accessor
+        @test variable_type(model, @varname(mu)) == ModelParameter
+        @test variable_type(model, @varname(sigma)) == ModelParameter
+        @test variable_type(model, @varname(x[1])) == ModelParameter
+        @test variable_type(model, @varname(mean_x)) == TransformedParameter
+        @test variable_type(model, @varname(y)) == Observation
+
+        # variable_type should error on nonexistent variables
+        @test_throws ArgumentError variable_type(model, @varname(nonexistent))
+
+        # Model with a stochastic generated quantity
+        model_def_gq = @bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            z ~ Normal(mu, 1)  # no observation depends on z
+        end
+
+        model_gq = compile(model_def_gq, (; y=1.0))
+
+        @test variable_type(model_gq, @varname(mu)) == ModelParameter
+        @test variable_type(model_gq, @varname(y)) == Observation
+        @test variable_type(model_gq, @varname(z)) == GeneratedQuantity
+
+        @test @varname(mu) in model_parameters(model_gq)
+        @test @varname(z) ∉ model_parameters(model_gq)
+        @test @varname(z) in generated_quantities(model_gq)
+
+        # Missing-data interpolation that influences observed likelihood
+        # should remain a model parameter.
+        model_def_missing = @bugs begin
+            x ~ Normal(0, 1)
+            y ~ Normal(x, 1)
+            z ~ Normal(y, 1)
+        end
+        model_missing = compile(model_def_missing, (; y=missing, z=1.0))
+
+        @test variable_type(model_missing, @varname(y)) == ModelParameter
+        @test @varname(y) in model_parameters(model_missing)
+        @test @varname(y) ∉ generated_quantities(model_missing)
+
+        # Unobserved stochastic node with no observed descendants
+        model_def_post = @bugs begin
+            θ ~ Normal(0, 1)
+            y ~ Normal(θ, 1)
+            z ~ Normal(θ, 1)
+        end
+        model_post = compile(model_def_post, (; y=1.0))
+
+        @test variable_type(model_post, @varname(z)) == GeneratedQuantity
+        @test @varname(z) ∉ model_parameters(model_post)
+        @test @varname(z) in generated_quantities(model_post)
+
+        # Deterministic node with no observed descendants
+        model_def_det_gq = @bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            pred = mu + 1.0
+        end
+        model_det_gq = compile(model_def_det_gq, (; y=1.0))
+
+        @test variable_type(model_det_gq, @varname(pred)) == GeneratedQuantity
+        @test @varname(pred) in generated_quantities(model_det_gq)
+    end
+
+    @testset "Classification invariants" begin
+        model_def = @bugs begin
+            mu ~ Normal(0, 10)
+            sigma ~ Gamma(1, 1)
+            for i in 1:3
+                x[i] ~ Normal(mu, sigma)
+            end
+            mean_x = mean(x[:])
+            y ~ Normal(mean_x, 1)
+            z ~ Normal(mu, 1)
+            pred = mu + sigma
+        end
+
+        model = compile(model_def, (; y=2.5))
+        mp = model_parameters(model)
+        gq = generated_quantities(model)
+
+        # model_parameters and generated_quantities are disjoint
+        @test isempty(intersect(Set(mp), Set(gq)))
+
+        # Every unobserved stochastic node is in exactly one partition
+        for vn in parameters(model)
+            @test (vn in mp) ⊻ (vn in gq)
+        end
+
+        # Deterministic nodes with no observed descendants are in generated_quantities
+        @test @varname(pred) in gq
+
+        # TransformedParameters are in neither
+        @test @varname(mean_x) ∉ mp
+        @test @varname(mean_x) ∉ gq
     end
 
     @testset "initialize!" begin

--- a/JuliaBUGS/test/model/evaluation.jl
+++ b/JuliaBUGS/test/model/evaluation.jl
@@ -361,13 +361,13 @@ end
 
     @testset "blockers" begin
         test_bugs_model_log_density(
-            JuliaBUGS.BUGSExamples.VOLUME_1.blockers, -8418.416388326123
+            JuliaBUGS.BUGSExamples.VOLUME_1.blockers, -8417.497576569103
         )
     end
 
     @testset "bones" begin
         test_bugs_model_log_density(
-            JuliaBUGS.BUGSExamples.VOLUME_1.bones, -161.6492002285034
+            JuliaBUGS.BUGSExamples.VOLUME_1.bones, -139.03545202758394
         )
     end
 

--- a/JuliaBUGS/test/model/evaluation.jl
+++ b/JuliaBUGS/test/model/evaluation.jl
@@ -668,3 +668,36 @@ end
         @test isa(logp, Real)
     end
 end
+
+@testset "forward_sample_generated_quantities!!" begin
+    model_def = @bugs begin
+        mu ~ Normal(0, 1)
+        y ~ Normal(mu, 1)
+        z ~ Normal(mu, 1)       # stochastic generated quantity
+        z2 ~ Normal(z, 1)       # chained stochastic generated quantity
+        pred = mu + 1.0         # deterministic generated quantity
+    end
+    model = compile(model_def, (; y=0.5))
+    fsgq = JuliaBUGS.Model.forward_sample_generated_quantities!!
+
+    base_env, _ = AbstractPPL.evaluate!!(model, JuliaBUGS.getparams(model))
+    mu0 = AbstractPPL.getvalue(base_env, @varname(mu))
+
+    e1 = fsgq(StableRNG(1), model, deepcopy(base_env))
+    e2 = fsgq(StableRNG(2), model, deepcopy(base_env))
+    e1b = fsgq(StableRNG(1), model, deepcopy(base_env))
+
+    # Model parameter and observation are left untouched.
+    @test AbstractPPL.getvalue(e1, @varname(mu)) == mu0
+    @test AbstractPPL.getvalue(e1, @varname(y)) == 0.5
+
+    # Stochastic generated quantities are redrawn; different rng -> different values.
+    @test AbstractPPL.getvalue(e1, @varname(z)) != AbstractPPL.getvalue(e2, @varname(z))
+    @test AbstractPPL.getvalue(e1, @varname(z2)) != AbstractPPL.getvalue(e2, @varname(z2))
+
+    # Same rng -> identical draws.
+    @test AbstractPPL.getvalue(e1, @varname(z)) == AbstractPPL.getvalue(e1b, @varname(z))
+
+    # Deterministic generated quantity is recomputed from its (sampled) parents.
+    @test AbstractPPL.getvalue(e1, @varname(pred)) ≈ mu0 + 1.0
+end

--- a/JuliaBUGS/test/model/evaluation.jl
+++ b/JuliaBUGS/test/model/evaluation.jl
@@ -426,6 +426,27 @@ end
         @test log_densities.logprior ≈ expected_logprior
         @test log_densities.loglikelihood ≈ expected_loglikelihood
     end
+
+    @testset "Excluded generated quantities are not evaluated" begin
+        model_def = @bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            z ~ Exponential(1)
+            w ~ Gamma(z, 1)
+        end
+
+        model = compile(model_def, (; y=0.0))
+        stale_env = JuliaBUGS.BangBang.setindex!!(model.evaluation_env, -1.0, @varname(z))
+
+        _, ld_excl = JuliaBUGS.evaluate_with_env!!(
+            model, stale_env; include_generated_quantities=false
+        )
+        @test isfinite(ld_excl.tempered_logjoint)
+
+        @test_throws DomainError JuliaBUGS.evaluate_with_env!!(
+            model, stale_env; include_generated_quantities=true
+        )
+    end
 end
 
 @testset "evaluate_with_values!!" begin

--- a/JuliaBUGS/test/model/to_distribution.jl
+++ b/JuliaBUGS/test/model/to_distribution.jl
@@ -82,41 +82,41 @@
         @test logpdf(d, nt) ≈ manual
     end
 
-    @testset "partially observed array" begin
-        model_def = @bugs begin
-            for i in 1:4
-                x[i] ~ Normal(0, 1)
-            end
-        end
-        model = compile(model_def, (; x=[missing, 1.0, missing, 2.0]))
-        d = to_distribution(model)
+    # @testset "partially observed array" begin
+    #    model_def = @bugs begin
+    #         for i in 1:4
+    #             x[i] ~ Normal(0, 1)
+    #         end
+    #     end
+    #     model = compile(model_def, (; x=[missing, 1.0, missing, 2.0]))
+    #     d = to_distribution(model)
 
-        # rand bakes the model's observed data into the observed slots.
-        nt = rand(MersenneTwister(0), d)
-        @test nt.x[2] == 1.0
-        @test nt.x[4] == 2.0
+    #     # rand bakes the model's observed data into the observed slots.
+    #     nt = rand(MersenneTwister(0), d)
+    #     @test nt.x[2] == 1.0
+    #     @test nt.x[4] == 2.0
 
-        # logpdf is the full joint, but the observed slots are scored against the MODEL's
-        # data, never against the caller's input: only the free parameters (x[1], x[3]) are
-        # read from the supplied NamedTuple. So logpdf is invariant to whatever sits in the
-        # observed slots (x[2], x[4]).
-        free1, free3 = nt.x[1], nt.x[3]
-        expected =
-            logpdf(Normal(0, 1), free1) +
-            logpdf(Normal(0, 1), free3) +    # free parameters x[1], x[3]
-            logpdf(Normal(0, 1), 1.0) +
-            logpdf(Normal(0, 1), 2.0)        # observed data x[2], x[4] (from the model)
-        @test logpdf(d, nt) ≈ expected
+    #     # logpdf is the full joint, but the observed slots are scored against the MODEL's
+    #     # data, never against the caller's input: only the free parameters (x[1], x[3]) are
+    #     # read from the supplied NamedTuple. So logpdf is invariant to whatever sits in the
+    #     # observed slots (x[2], x[4]).
+    #     free1, free3 = nt.x[1], nt.x[3]
+    #     expected =
+    #         logpdf(Normal(0, 1), free1) +
+    #         logpdf(Normal(0, 1), free3) +    # free parameters x[1], x[3]
+    #         logpdf(Normal(0, 1), 1.0) +
+    #         logpdf(Normal(0, 1), 2.0)        # observed data x[2], x[4] (from the model)
+    #     @test logpdf(d, nt) ≈ expected
 
-        # Tampering with the observed slots must not change the density (the bug: it did).
-        tampered = (; x=[free1, 999.0, free3, -888.0])
-        @test logpdf(d, tampered) ≈ expected
-        @test logpdf(d, tampered) ≈ logpdf(d, nt)
+    #     # Tampering with the observed slots must not change the density (the bug: it did).
+    #     tampered = (; x=[free1, 999.0, free3, -888.0])
+    #     @test logpdf(d, tampered) ≈ expected
+    #     @test logpdf(d, tampered) ≈ logpdf(d, nt)
 
-        # logpdf must not corrupt the model's stored data.
-        @test model.evaluation_env.x[2] == 1.0
-        @test model.evaluation_env.x[4] == 2.0
-    end
+    #     # logpdf must not corrupt the model's stored data.
+    #     @test model.evaluation_env.x[2] == 1.0
+    #     @test model.evaluation_env.x[4] == 2.0
+    # end
 
     @testset "mixed discrete/continuous" begin
         model_def = @bugs begin

--- a/JuliaBUGS/test/model/to_distribution.jl
+++ b/JuliaBUGS/test/model/to_distribution.jl
@@ -171,6 +171,33 @@
         @test logpdf(d, NamedTuple()) ≈ manual
     end
 
+    @testset "generated-mode model keeps stochastic generated quantities" begin
+        model_def = @bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            z ~ Normal(mu, 1)
+        end
+        model = compile(model_def, (; y=0.5))
+        generated_model = JuliaBUGS.Model.set_evaluation_mode(
+            model, JuliaBUGS.Model.UseGeneratedLogDensityFunction()
+        )
+        @test Set(JuliaBUGS.Model.parameters(generated_model)) ==
+            Set(JuliaBUGS.Model.parameters(model))
+
+        distribution = @test_logs (:warn,) match_mode = :any to_distribution(
+            generated_model
+        )
+        @test distribution isa Distribution{Distributions.NamedTupleVariate{(:mu, :z)}}
+
+        parameter_values = (mu=0.1, z=0.2)
+        expected_logdensity =
+            logpdf(Normal(0, 1), parameter_values.mu) +
+            logpdf(Normal(parameter_values.mu, 1), 0.5) +
+            logpdf(Normal(parameter_values.mu, 1), parameter_values.z)
+        @test logpdf(distribution, parameter_values) ≈ expected_logdensity
+        @test_throws ArgumentError logpdf(distribution, (; mu=parameter_values.mu))
+    end
+
     @testset "multivariate parameter nodes" begin
         # A single multivariate stochastic node packs into one NamedTuple field.
         @testset "ddirich (simplex-valued)" begin

--- a/JuliaBUGS/test/model/to_distribution.jl
+++ b/JuliaBUGS/test/model/to_distribution.jl
@@ -82,41 +82,41 @@
         @test logpdf(d, nt) ≈ manual
     end
 
-    # @testset "partially observed array" begin
-    #    model_def = @bugs begin
-    #         for i in 1:4
-    #             x[i] ~ Normal(0, 1)
-    #         end
-    #     end
-    #     model = compile(model_def, (; x=[missing, 1.0, missing, 2.0]))
-    #     d = to_distribution(model)
+    @testset "partially observed array" begin
+        model_def = @bugs begin
+            for i in 1:4
+                x[i] ~ Normal(0, 1)
+            end
+        end
+        model = compile(model_def, (; x=[missing, 1.0, missing, 2.0]))
+        d = to_distribution(model)
 
-    #     # rand bakes the model's observed data into the observed slots.
-    #     nt = rand(MersenneTwister(0), d)
-    #     @test nt.x[2] == 1.0
-    #     @test nt.x[4] == 2.0
+        # rand bakes the model's observed data into the observed slots.
+        nt = rand(MersenneTwister(0), d)
+        @test nt.x[2] == 1.0
+        @test nt.x[4] == 2.0
 
-    #     # logpdf is the full joint, but the observed slots are scored against the MODEL's
-    #     # data, never against the caller's input: only the free parameters (x[1], x[3]) are
-    #     # read from the supplied NamedTuple. So logpdf is invariant to whatever sits in the
-    #     # observed slots (x[2], x[4]).
-    #     free1, free3 = nt.x[1], nt.x[3]
-    #     expected =
-    #         logpdf(Normal(0, 1), free1) +
-    #         logpdf(Normal(0, 1), free3) +    # free parameters x[1], x[3]
-    #         logpdf(Normal(0, 1), 1.0) +
-    #         logpdf(Normal(0, 1), 2.0)        # observed data x[2], x[4] (from the model)
-    #     @test logpdf(d, nt) ≈ expected
+        # logpdf is the full joint, but the observed slots are scored against the MODEL's
+        # data, never against the caller's input: only the free parameters (x[1], x[3]) are
+        # read from the supplied NamedTuple. So logpdf is invariant to whatever sits in the
+        # observed slots (x[2], x[4]).
+        free1, free3 = nt.x[1], nt.x[3]
+        expected =
+            logpdf(Normal(0, 1), free1) +
+            logpdf(Normal(0, 1), free3) +    # free parameters x[1], x[3]
+            logpdf(Normal(0, 1), 1.0) +
+            logpdf(Normal(0, 1), 2.0)        # observed data x[2], x[4] (from the model)
+        @test logpdf(d, nt) ≈ expected
 
-    #     # Tampering with the observed slots must not change the density (the bug: it did).
-    #     tampered = (; x=[free1, 999.0, free3, -888.0])
-    #     @test logpdf(d, tampered) ≈ expected
-    #     @test logpdf(d, tampered) ≈ logpdf(d, nt)
+        # Tampering with the observed slots must not change the density (the bug: it did).
+        tampered = (; x=[free1, 999.0, free3, -888.0])
+        @test logpdf(d, tampered) ≈ expected
+        @test logpdf(d, tampered) ≈ logpdf(d, nt)
 
-    #     # logpdf must not corrupt the model's stored data.
-    #     @test model.evaluation_env.x[2] == 1.0
-    #     @test model.evaluation_env.x[4] == 2.0
-    # end
+        # logpdf must not corrupt the model's stored data.
+        @test model.evaluation_env.x[2] == 1.0
+        @test model.evaluation_env.x[4] == 2.0
+    end
 
     @testset "mixed discrete/continuous" begin
         model_def = @bugs begin

--- a/JuliaBUGS/test/source_gen.jl
+++ b/JuliaBUGS/test/source_gen.jl
@@ -269,3 +269,225 @@ end
         @test isapprox(ld_graph, ld_gen; rtol=1e-10)
     end
 end
+
+@testset "generated quantities in generated log-density function" begin
+    # A generated quantity (GQ) is an unobserved node (stochastic or deterministic) that
+    # cannot reach any observation, so it contributes nothing to the model log density and
+    # the generated function must drop its `~`/`=` statement entirely. The helper below
+    # asserts the invariants the feature must uphold for each model:
+    #
+    #   I1  Mode-invariance: `model_parameters`, `generated_quantities`, and `dimension`
+    #       are identical between `UseGraph` and `UseGeneratedLogDensityFunction`. (This is
+    #       exactly what the conditioning/regeneration consistency bug used to violate.)
+    #   I2  Partition: a node is never both a model parameter and a generated quantity, and
+    #       `model_parameters ⊆ parameters ⊆ model_parameters ∪ generated_quantities`
+    #       (`parameters` additionally holds the stochastic generated quantities).
+    #   I3  Dimension reflects model parameters only: `dimension == length(getparams)` and
+    #       no generated quantity appears in the parameter vector.
+    #   I4  Generated ≡ graph: equal log density at matched parameter values, flattening
+    #       parameters in each model's own ordering (the generated model re-orders nodes to
+    #       loop-execution order).
+    #   I5  Generated quantities do not enter the log density: re-forward-sampling the GQ
+    #       (which changes only GQ values, leaving parameters and observations fixed) leaves
+    #       both `getparams` and the log density unchanged, in both modes.
+    JuliaBUGS.@bugs_primitive Normal
+
+    fsgq = JuliaBUGS.Model.forward_sample_generated_quantities!!
+
+    # `n_params` is the number of (scalar) model parameters = the expected `dimension`;
+    # `n_gq` the number of generated-quantity nodes; `has_stochastic_gq` whether at least
+    # one GQ is stochastic (so re-sampling actually perturbs the environment).
+    function check_gq_invariants(model; n_params, n_gq, has_stochastic_gq)
+        m_graph = JuliaBUGS.set_evaluation_mode(model, JuliaBUGS.UseGraph())
+        m_gen = JuliaBUGS.set_evaluation_mode(
+            model, JuliaBUGS.UseGeneratedLogDensityFunction()
+        )
+        @test !isnothing(m_gen.log_density_computation_function)
+
+        mp = Set(JuliaBUGS.model_parameters(m_graph))
+        gq = Set(JuliaBUGS.generated_quantities(m_graph))
+        allpar = Set(JuliaBUGS.parameters(m_graph))
+        dim = LogDensityProblems.dimension(m_graph)
+
+        # I1: classification and dimension do not depend on the evaluation mode.
+        @test Set(JuliaBUGS.model_parameters(m_gen)) == mp
+        @test Set(JuliaBUGS.generated_quantities(m_gen)) == gq
+        @test LogDensityProblems.dimension(m_gen) == dim
+
+        # Per-model anchors so a silent reclassification can't pass unnoticed.
+        @test length(mp) == n_params
+        @test length(gq) == n_gq
+        @test dim == n_params
+
+        # I2: model parameters and generated quantities partition the unobserved
+        # stochastic nodes; `parameters` is their union (it also lists stochastic GQ).
+        @test isempty(intersect(mp, gq))
+        @test issubset(mp, allpar)
+        @test issubset(allpar, union(mp, gq))
+
+        # I3: the parameter vector covers exactly the model parameters; no GQ leaks in.
+        @test length(JuliaBUGS.getparams(m_graph)) == dim
+        param_keys = Set(keys(JuliaBUGS.getparams(Dict, m_graph)))
+        @test param_keys == mp
+        @test isempty(intersect(param_keys, gq))
+
+        # I4: generated log density matches graph evaluation at matched values.
+        for seed in 1:8
+            env, _ = Base.invokelatest(
+                JuliaBUGS.AbstractPPL.evaluate!!, Random.MersenneTwister(seed), model
+            )
+            xg = JuliaBUGS.getparams(m_graph, env)
+            xgen = JuliaBUGS.getparams(m_gen, env)
+            @test length(xg) == length(xgen) == dim
+            lp_graph = Base.invokelatest(LogDensityProblems.logdensity, m_graph, xg)
+            lp_gen = Base.invokelatest(LogDensityProblems.logdensity, m_gen, xgen)
+            @test isapprox(lp_graph, lp_gen; atol=1e-10)
+        end
+
+        # I5: log density is invariant to the values of generated quantities. Two forward
+        # samples differ only in their GQ values; parameters and log density must not move.
+        base_env, _ = Base.invokelatest(
+            JuliaBUGS.AbstractPPL.evaluate!!, Random.MersenneTwister(99), model
+        )
+        # `fsgq` calls the compiled node functions directly, so invoke it in the latest
+        # world age (the helper is defined before these models are compiled).
+        env_a = Base.invokelatest(
+            fsgq, Random.MersenneTwister(1), model, deepcopy(base_env)
+        )
+        env_b = Base.invokelatest(
+            fsgq, Random.MersenneTwister(2), model, deepcopy(base_env)
+        )
+        @test JuliaBUGS.getparams(m_graph, env_a) == JuliaBUGS.getparams(m_graph, env_b)
+        if has_stochastic_gq
+            # Guard against a vacuous test: the GQ values really did change.
+            @test any(
+                vn ->
+                    JuliaBUGS.AbstractPPL.getvalue(env_a, vn) !=
+                    JuliaBUGS.AbstractPPL.getvalue(env_b, vn),
+                gq,
+            )
+        end
+        for m in (m_graph, m_gen)
+            m_a = BangBang.setproperty!!(m, :evaluation_env, env_a)
+            m_b = BangBang.setproperty!!(m, :evaluation_env, env_b)
+            lp_a = Base.invokelatest(
+                LogDensityProblems.logdensity, m_a, JuliaBUGS.getparams(m_a)
+            )
+            lp_b = Base.invokelatest(
+                LogDensityProblems.logdensity, m_b, JuliaBUGS.getparams(m_b)
+            )
+            @test isapprox(lp_a, lp_b; atol=1e-10)
+        end
+        return nothing
+    end
+
+    @testset "scalar GQ (stochastic + deterministic)" begin
+        # z and pred are generated quantities; only mu is a parameter.
+        check_gq_invariants(
+            compile((@bugs begin
+                mu ~ Normal(0, 1)
+                y ~ Normal(mu, 1)
+                z ~ Normal(mu, 1)
+                pred = mu + 1.0
+            end), (; y=0.5));
+            n_params=1,
+            n_gq=2,
+            has_stochastic_gq=true,
+        )
+    end
+
+    @testset "chained GQ" begin
+        # z and z2 form a GQ chain hanging off mu.
+        check_gq_invariants(
+            compile((@bugs begin
+                mu ~ Normal(0, 1)
+                y ~ Normal(mu, 1)
+                z ~ Normal(mu, 1)
+                z2 ~ Normal(z, 1)
+            end), (; y=0.5));
+            n_params=1,
+            n_gq=2,
+            has_stochastic_gq=true,
+        )
+    end
+
+    @testset "all-GQ loop (entirely dropped)" begin
+        # The whole g[1:3] loop is generated quantities and must drop out.
+        check_gq_invariants(
+            compile((@bugs begin
+                mu ~ Normal(0, 1)
+                y ~ Normal(mu, 1)
+                for i in 1:3
+                    g[i] ~ Normal(mu, 1)
+                end
+            end), (; y=0.5));
+            n_params=1,
+            n_gq=3,
+            has_stochastic_gq=true,
+        )
+    end
+
+    @testset "partial-observation loop (observed + GQ siblings)" begin
+        # y[2], y[4] are missing with no observed descendant -> generated quantities.
+        check_gq_invariants(
+            compile((@bugs begin
+                mu ~ Normal(0, 1)
+                for i in 1:4
+                    y[i] ~ Normal(mu, 1)
+                end
+            end), (; y=[0.1, missing, 0.3, missing]));
+            n_params=1,
+            n_gq=2,
+            has_stochastic_gq=true,
+        )
+    end
+
+    @testset "mixed loops (observed + parameter in x, observed + GQ in z)" begin
+        # x[1], x[3] are parameters; x[2], x[4] observed; z[1], z[3] observed
+        # likelihoods; z[2], z[4] are generated quantities.
+        check_gq_invariants(
+            compile(
+                (@bugs begin
+                    for i in 1:4
+                        x[i] ~ Normal(0, 1)
+                        z[i] ~ Normal(x[i], 1)
+                    end
+                end),
+                (; x=[missing, 1.0, missing, 2.0], z=[0.5, missing, 0.7, missing]),
+            );
+            n_params=2,
+            n_gq=2,
+            has_stochastic_gq=true,
+        )
+    end
+
+    @testset "conditioning preserves classification (no-data model)" begin
+        # Compiling without data treats every node as a parameter (no-data shim). After
+        # conditioning x[1], x[3] the remaining x[2], y[1:3] stay parameters -- they must
+        # not be silently reclassified as generated quantities when the function is
+        # generated. This is the scenario the consistency bug broke.
+        model = compile((@bugs begin
+            for i in 1:3
+                x[i] ~ Normal(0, 1)
+            end
+            for i in 1:3
+                y[i] ~ Normal(x[i], 1)
+            end
+        end), (;))
+        model_cond = condition(model, Dict(@varname(x[1]) => 0.5, @varname(x[3]) => 1.5))
+        check_gq_invariants(model_cond; n_params=4, n_gq=0, has_stochastic_gq=false)
+    end
+
+    @testset "conditioning preserves a surviving generated quantity" begin
+        # z is a generated quantity of the original model; conditioning the only parameter
+        # mu must leave z classified as a generated quantity (preserved override) while the
+        # parameter space collapses to empty.
+        model = compile((@bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            z ~ Normal(mu, 1)
+        end), (; y=0.5))
+        model_cond = condition(model, Dict(@varname(mu) => 0.3))
+        check_gq_invariants(model_cond; n_params=0, n_gq=1, has_stochastic_gq=true)
+    end
+end

--- a/JuliaBUGS/test/source_gen.jl
+++ b/JuliaBUGS/test/source_gen.jl
@@ -409,6 +409,46 @@ end
         )
     end
 
+    @testset "_generate_lowered_model_def derives GQ classification by default" begin
+        model = compile((@bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            z ~ Normal(mu, 1)
+            pred = mu + 1.0
+        end), (; y=0.5))
+
+        lowered_default, _ = JuliaBUGS._generate_lowered_model_def(
+            model.model_def, model.g, model.evaluation_env
+        )
+        lowered_cached, _ = JuliaBUGS._generate_lowered_model_def(
+            model.model_def,
+            model.g,
+            model.evaluation_env;
+            generated_quantities=Set(JuliaBUGS.generated_quantities(model)),
+        )
+        @test lowered_default == lowered_cached
+    end
+
+    @testset "prior-only deterministic ancestor of stochastic parameter" begin
+        model = compile((@bugs begin
+            x ~ Normal(0, 1)
+            h = x + 1
+            y ~ Normal(h, 1)
+        end), (;))
+
+        @test JuliaBUGS.variable_type(model, @varname(h)) == JuliaBUGS.TransformedParameter
+        check_gq_invariants(model; n_params=2, n_gq=0, has_stochastic_gq=false)
+
+        graph_model = JuliaBUGS.set_evaluation_mode(model, JuliaBUGS.UseGraph())
+        generated_model = JuliaBUGS.set_evaluation_mode(
+            model, JuliaBUGS.UseGeneratedLogDensityFunction()
+        )
+        for values in ([0.0, 0.0], [1.0, 2.0], [-2.0, 0.5])
+            @test LogDensityProblems.logdensity(graph_model, values) ≈
+                LogDensityProblems.logdensity(generated_model, values)
+        end
+    end
+
     @testset "chained GQ" begin
         # z and z2 form a GQ chain hanging off mu.
         check_gq_invariants(

--- a/JuliaBUGS/test/source_gen.jl
+++ b/JuliaBUGS/test/source_gen.jl
@@ -495,6 +495,24 @@ end
         )
     end
 
+    @testset "single statement mixes observed, parameter, and GQ iterations" begin
+        model = compile(
+            (@bugs begin
+                mu ~ Normal(0, 1)
+                for i in 1:3
+                    y[i] ~ Normal(mu, 1)
+                    z[i] ~ Normal(y[i], 1)
+                end
+            end),
+            (; y=[0.1, missing, missing], z=[missing, 0.2, missing]),
+        )
+
+        @test JuliaBUGS.variable_type(model, @varname(y[1])) == JuliaBUGS.Observation
+        @test JuliaBUGS.variable_type(model, @varname(y[2])) == JuliaBUGS.ModelParameter
+        @test JuliaBUGS.variable_type(model, @varname(y[3])) == JuliaBUGS.GeneratedQuantity
+        check_gq_invariants(model; n_params=2, n_gq=3, has_stochastic_gq=true)
+    end
+
     @testset "mixed loops (observed + parameter in x, observed + GQ in z)" begin
         # x[1], x[3] are parameters; x[2], x[4] observed; z[1], z[3] observed
         # likelihoods; z[2], z[4] are generated quantities.

--- a/JuliaBUGS/test/source_gen.jl
+++ b/JuliaBUGS/test/source_gen.jl
@@ -292,56 +292,62 @@ end
     #       both `getparams` and the log density unchanged, in both modes.
     JuliaBUGS.@bugs_primitive Normal
 
-    fsgq = JuliaBUGS.Model.forward_sample_generated_quantities!!
+    forward_sample_generated_quantities =
+        JuliaBUGS.Model.forward_sample_generated_quantities!!
 
     # `n_params` is the number of (scalar) model parameters = the expected `dimension`;
     # `n_gq` the number of generated-quantity nodes; `has_stochastic_gq` whether at least
     # one GQ is stochastic (so re-sampling actually perturbs the environment).
     function check_gq_invariants(model; n_params, n_gq, has_stochastic_gq)
-        m_graph = JuliaBUGS.set_evaluation_mode(model, JuliaBUGS.UseGraph())
-        m_gen = JuliaBUGS.set_evaluation_mode(
+        graph_model = JuliaBUGS.set_evaluation_mode(model, JuliaBUGS.UseGraph())
+        generated_model = JuliaBUGS.set_evaluation_mode(
             model, JuliaBUGS.UseGeneratedLogDensityFunction()
         )
-        @test !isnothing(m_gen.log_density_computation_function)
+        @test !isnothing(generated_model.log_density_computation_function)
 
-        mp = Set(JuliaBUGS.model_parameters(m_graph))
-        gq = Set(JuliaBUGS.generated_quantities(m_graph))
-        allpar = Set(JuliaBUGS.parameters(m_graph))
-        dim = LogDensityProblems.dimension(m_graph)
+        model_parameter_set = Set(JuliaBUGS.model_parameters(graph_model))
+        generated_quantity_set = Set(JuliaBUGS.generated_quantities(graph_model))
+        parameter_set = Set(JuliaBUGS.parameters(graph_model))
+        dimension = LogDensityProblems.dimension(graph_model)
 
         # I1: classification and dimension do not depend on the evaluation mode.
-        @test Set(JuliaBUGS.model_parameters(m_gen)) == mp
-        @test Set(JuliaBUGS.generated_quantities(m_gen)) == gq
-        @test LogDensityProblems.dimension(m_gen) == dim
+        @test Set(JuliaBUGS.model_parameters(generated_model)) == model_parameter_set
+        @test Set(JuliaBUGS.generated_quantities(generated_model)) == generated_quantity_set
+        @test Set(JuliaBUGS.parameters(generated_model)) == parameter_set
+        @test LogDensityProblems.dimension(generated_model) == dimension
 
         # Per-model anchors so a silent reclassification can't pass unnoticed.
-        @test length(mp) == n_params
-        @test length(gq) == n_gq
-        @test dim == n_params
+        @test length(model_parameter_set) == n_params
+        @test length(generated_quantity_set) == n_gq
+        @test dimension == n_params
 
         # I2: model parameters and generated quantities partition the unobserved
         # stochastic nodes; `parameters` is their union (it also lists stochastic GQ).
-        @test isempty(intersect(mp, gq))
-        @test issubset(mp, allpar)
-        @test issubset(allpar, union(mp, gq))
+        @test isempty(intersect(model_parameter_set, generated_quantity_set))
+        @test issubset(model_parameter_set, parameter_set)
+        @test issubset(parameter_set, union(model_parameter_set, generated_quantity_set))
 
         # I3: the parameter vector covers exactly the model parameters; no GQ leaks in.
-        @test length(JuliaBUGS.getparams(m_graph)) == dim
-        param_keys = Set(keys(JuliaBUGS.getparams(Dict, m_graph)))
-        @test param_keys == mp
-        @test isempty(intersect(param_keys, gq))
+        @test length(JuliaBUGS.getparams(graph_model)) == dimension
+        param_keys = Set(keys(JuliaBUGS.getparams(Dict, graph_model)))
+        @test param_keys == model_parameter_set
+        @test isempty(intersect(param_keys, generated_quantity_set))
 
         # I4: generated log density matches graph evaluation at matched values.
         for seed in 1:8
             env, _ = Base.invokelatest(
                 JuliaBUGS.AbstractPPL.evaluate!!, Random.MersenneTwister(seed), model
             )
-            xg = JuliaBUGS.getparams(m_graph, env)
-            xgen = JuliaBUGS.getparams(m_gen, env)
-            @test length(xg) == length(xgen) == dim
-            lp_graph = Base.invokelatest(LogDensityProblems.logdensity, m_graph, xg)
-            lp_gen = Base.invokelatest(LogDensityProblems.logdensity, m_gen, xgen)
-            @test isapprox(lp_graph, lp_gen; atol=1e-10)
+            graph_parameters = JuliaBUGS.getparams(graph_model, env)
+            generated_parameters = JuliaBUGS.getparams(generated_model, env)
+            @test length(graph_parameters) == length(generated_parameters) == dimension
+            graph_logdensity = Base.invokelatest(
+                LogDensityProblems.logdensity, graph_model, graph_parameters
+            )
+            generated_logdensity = Base.invokelatest(
+                LogDensityProblems.logdensity, generated_model, generated_parameters
+            )
+            @test isapprox(graph_logdensity, generated_logdensity; atol=1e-10)
         end
 
         # I5: log density is invariant to the values of generated quantities. Two forward
@@ -349,25 +355,32 @@ end
         base_env, _ = Base.invokelatest(
             JuliaBUGS.AbstractPPL.evaluate!!, Random.MersenneTwister(99), model
         )
-        # `fsgq` calls the compiled node functions directly, so invoke it in the latest
+        # This helper calls the compiled node functions directly, so invoke it in the latest
         # world age (the helper is defined before these models are compiled).
         env_a = Base.invokelatest(
-            fsgq, Random.MersenneTwister(1), model, deepcopy(base_env)
+            forward_sample_generated_quantities,
+            Random.MersenneTwister(1),
+            model,
+            deepcopy(base_env),
         )
         env_b = Base.invokelatest(
-            fsgq, Random.MersenneTwister(2), model, deepcopy(base_env)
+            forward_sample_generated_quantities,
+            Random.MersenneTwister(2),
+            model,
+            deepcopy(base_env),
         )
-        @test JuliaBUGS.getparams(m_graph, env_a) == JuliaBUGS.getparams(m_graph, env_b)
+        @test JuliaBUGS.getparams(graph_model, env_a) ==
+            JuliaBUGS.getparams(graph_model, env_b)
         if has_stochastic_gq
             # Guard against a vacuous test: the GQ values really did change.
             @test any(
                 vn ->
                     JuliaBUGS.AbstractPPL.getvalue(env_a, vn) !=
                     JuliaBUGS.AbstractPPL.getvalue(env_b, vn),
-                gq,
+                generated_quantity_set,
             )
         end
-        for m in (m_graph, m_gen)
+        for m in (graph_model, generated_model)
             m_a = BangBang.setproperty!!(m, :evaluation_env, env_a)
             m_b = BangBang.setproperty!!(m, :evaluation_env, env_b)
             lp_a = Base.invokelatest(
@@ -474,8 +487,10 @@ end
                 y[i] ~ Normal(x[i], 1)
             end
         end), (;))
-        model_cond = condition(model, Dict(@varname(x[1]) => 0.5, @varname(x[3]) => 1.5))
-        check_gq_invariants(model_cond; n_params=4, n_gq=0, has_stochastic_gq=false)
+        conditioned_model = condition(
+            model, Dict(@varname(x[1]) => 0.5, @varname(x[3]) => 1.5)
+        )
+        check_gq_invariants(conditioned_model; n_params=4, n_gq=0, has_stochastic_gq=false)
     end
 
     @testset "conditioning preserves a surviving generated quantity" begin
@@ -487,7 +502,7 @@ end
             y ~ Normal(mu, 1)
             z ~ Normal(mu, 1)
         end), (; y=0.5))
-        model_cond = condition(model, Dict(@varname(mu) => 0.3))
-        check_gq_invariants(model_cond; n_params=0, n_gq=1, has_stochastic_gq=true)
+        conditioned_model = condition(model, Dict(@varname(mu) => 0.3))
+        check_gq_invariants(conditioned_model; n_params=0, n_gq=1, has_stochastic_gq=true)
     end
 end


### PR DESCRIPTION
fix https://github.com/TuringLang/JuliaBUGS.jl/issues/327

## Summary

Consolidates the `variabletype_enum` line of work into `main`. It introduces an explicit per-node **variable-type classification** and uses it to separate **generated quantities** — unobserved nodes (stochastic or deterministic) outside the log-density target dependency closure — from the MCMC target. Generated quantities are excluded from the log density in every evaluation mode and recovered afterwards by forward sampling, instead of being sampled during inference. Support is complete across all three evaluation modes, including discrete-latent recovery and chain reconstruction for auto-marginalized models.

## Classification

Every node is assigned a `VariableType`:

- `Observation` — stochastic node with observed data.
- `ModelParameter` — unobserved stochastic node that influences observations. These are what MCMC samples; they make up the parameter vector and `LogDensityProblems.dimension`.
- `TransformedParameter` — deterministic node needed to evaluate the target density.
- `GeneratedQuantity` — unobserved node (stochastic or deterministic) outside the target dependency closure; forward-sampled in post-processing.

Model parameters and generated quantities are disjoint, and no model parameter or observation ever has a generated quantity as an ancestor.

## Behavior

A generated quantity is excluded from the log density in **every** evaluation mode and recovered by forward sampling:

| | log density excludes GQ | forward-sample GQ |
|---|---|---|
| `UseGraph` | ✅ | ✅ |
| `UseGeneratedLogDensityFunction` | ✅ (generated source drops the GQ statements) | ✅ |
| `UseAutoMarginalization` | ✅ | ✅ (recovers marginalized discrete latents from `p(z\|θ,y)` first) |

The no-observation behavior is preserved: a model with no data keeps all unobserved stochastic nodes as model parameters (prior sampling); only terminal deterministic nodes that feed no stochastic factor remain generated quantities.

## Public API

New names, exported from the `JuliaBUGS.Model` submodule (like the existing `parameters`) — reachable as `JuliaBUGS.model_parameters`, etc., not via `using JuliaBUGS`:

- `model_parameters(model)`, `generated_quantities(model)`, `variable_type(model, vn)`.
- `VariableType` and its instances `Observation`, `ModelParameter`, `TransformedParameter`, `GeneratedQuantity`.

Plus `JuliaBUGS.Model.forward_sample_generated_quantities!!(rng, model[, env])` (unexported) — applied automatically by `gen_chains`, so reported generated quantities are genuine posterior(-predictive) draws.

## ⚠️ Breaking changes

- Unobserved stochastic nodes with **no observed descendants** (e.g. posterior-predictive draws, priors not used by any likelihood) are now **generated quantities**: excluded from `model_parameters`, the parameter vector, and `LogDensityProblems.dimension`, and forward-sampled in post-processing rather than sampled by MCMC/Gibbs. (The resulting joint is unchanged — forward-sampling a node from its conditional given its parents is identical to sampling it as a free parameter.)
- `parameters(model)` (all unobserved stochastic nodes) and `model_parameters(model)` (the MCMC target) now differ; `dimension` follows `model_parameters`. Code that assumed `length(parameters(model)) == dimension` should switch to `model_parameters` / `dimension`.
- `Gibbs` sampler maps that reference a now-reclassified variable will error, since it is no longer in `model_parameters`.

## What's included

| PR | Change |
|----|--------|
| #489 | Variable-type enum scaffolding (`Observation`, `ModelParameter`, `TransformedParameter`, `GeneratedQuantity`) |
| #490 | Route `model_parameters` through the classification |
| #496 | Unify the generated-quantity partition with a per-node mask |
| #497 | Forward-sample generated quantities (`forward_sample_generated_quantities!!`) |
| #498 | Support generated quantities in the generated log-density function |
| #499 | Generated quantities under auto-marginalization (log density + case-3 latent recovery) |
| #500 | Document generated quantities |
| #504 | End-to-end `gen_chains` support for auto-marginalized models (continuous-only environment reconstruction + recovered finite discrete latents) |
| #505 | Finalize cleanup: reclassify ancestors after conditioning, rename `gq_override → generated_quantities`, cache `continuous_model_parameters` on the marginalization cache |
| #507 | Fix the GQ target closure: reclassify prior-only deterministic ancestors as transformed parameters, derive the cached GQ classification by default in source generation, and align auto-marginalized `ParamsWithStats` with the continuous flat parameter vector |
| #508 | Shrink generated-source guards by selecting the smaller kept/dropped iteration set, and skip deterministic-GQ branches when recomputation is cheaper than guarding |

Plus two direct commits: dropping `invokelatest` from marginalized evaluation, and a `gibbs.jl` test update reflecting the reclassification.

## Tests

Each PR added focused tests; together they cover the classification, the per-node mask, generated-vs-graph log-density agreement, an invariant battery (mode-invariance, partition, GQ-independence, dimension), marginalized-target invariance against a forward-algorithm reference, backward-sampling correctness against an analytic HMM posterior (empirical distribution of the recovered discrete latents), and auto-marginalized `gen_chains` reconstruction from continuous-only samples. CI is green.
