### PR TITLE
Support auto-marginalized chain reconstruction

### DIFF
--- a/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
@@ -134,7 +134,8 @@ function JuliaBUGS.gen_chains(
     kwargs...,
 )
     gd = model.graph_evaluation_data
-    # Filter parameters based on evaluation mode and MCMC partition.
+    # Report model parameters. In auto-marginalization, continuous parameters come from
+    # the sample row and finite discrete latents are recovered below from p(z | theta, y).
     param_vars = model_parameters(model)
 
     # Generated quantities (no observed descendants) are reported in topological order;
@@ -155,8 +156,7 @@ function JuliaBUGS.gen_chains(
         # draws rather than the stale environment values left by `evaluate!!`.
         evaluation_env = forward_sample_generated_quantities!!(rng, model, evaluation_env)
 
-        # Get parameter values from the evaluation environment
-        # (they were just set by evaluate!!, so they match samples[i])
+        # Get parameter values from the reconstructed evaluation environment.
         push!(
             param_vals,
             [AbstractPPL.getvalue(evaluation_env, param_var) for param_var in param_vars],

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -258,6 +258,49 @@ function evaluate_with_values!!(
     )
 end
 
+function _evaluate_active_parameters_with_values!!(
+    model::BUGSModel, flattened_values::AbstractVector; transformed=true
+)
+    var_lengths = if transformed
+        model.transformed_var_lengths
+    else
+        model.untransformed_var_lengths
+    end
+
+    evaluation_env = smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols)
+    active_parameters = Set(_active_parameters(model))
+    current_idx = 1
+
+    gd = model.graph_evaluation_data
+    for (i, vn) in enumerate(gd.sorted_nodes)
+        node_function = gd.node_function_vals[i]
+        loop_vars = gd.loop_vars_vals[i]
+
+        if gd.variable_types[i] == GeneratedQuantity
+            continue
+        elseif !gd.is_stochastic_vals[i]
+            value = Base.invokelatest(node_function, evaluation_env, loop_vars)
+            evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
+        elseif !gd.is_observed_vals[i] && vn in active_parameters
+            dist = Base.invokelatest(node_function, evaluation_env, loop_vars)
+            l = var_lengths[vn]
+            value = if transformed
+                b_inv = Bijectors.inverse(Bijectors.bijector(dist))
+                reconstructed_value = reconstruct(
+                    b_inv, dist, view(flattened_values, current_idx:(current_idx + l - 1))
+                )
+                first(Bijectors.with_logabsdet_jacobian(b_inv, reconstructed_value))
+            else
+                reconstruct(dist, view(flattened_values, current_idx:(current_idx + l - 1)))
+            end
+            current_idx += l
+            evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
+        end
+    end
+
+    return evaluation_env
+end
+
 """
     forward_sample_generated_quantities!!(
         rng::Random.AbstractRNG,
@@ -865,7 +908,9 @@ function evaluate_with_marginalization_values!!(
     memo = Dict{Tuple{Int,Tuple},Tuple{T,T}}()
     sizehint!(memo, expected_entries)
 
-    evaluation_env = smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols)
+    evaluation_env = _evaluate_active_parameters_with_values!!(
+        model, flattened_values; transformed=model.transformed
+    )
 
     log_prior, log_likelihood = _marginalize_recursive(
         model,

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -287,7 +287,9 @@ function _evaluate_active_parameters_with_values!!(
             value = if transformed
                 b_inv = Bijectors.inverse(Bijectors.bijector(dist))
                 reconstructed_value = reconstruct(
-                    b_inv, dist, view(flattened_values, current_idx:(current_idx + l - 1))
+                    b_inv,
+                    dist,
+                    view(flattened_values, current_idx:(current_idx + l - 1)),
                 )
                 first(Bijectors.with_logabsdet_jacobian(b_inv, reconstructed_value))
             else

--- a/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
@@ -162,3 +162,34 @@ end
     # Model-parameter column matches the synthetic samples in order.
     @test mucol ≈ [s[1] for s in samples]
 end
+
+@testset "auto-marginalized chains reconstruct generated quantities from samples" begin
+    model_def = @bugs begin
+        mu ~ Normal(0, 1)
+        z ~ Categorical(w[1:2])
+        y ~ Normal(mu + z, 1)
+        pred = mu + 1.0
+    end
+
+    model = compile(model_def, (; w=[0.5, 0.5], y=1.0))
+    model = JuliaBUGS.settrans(model, true)
+    model = JuliaBUGS.set_evaluation_mode(model, JuliaBUGS.UseAutoMarginalization())
+    @test LogDensityProblems.dimension(model) == 1
+
+    samples = [[m] for m in range(-1.0, 1.0; length=25)]
+    chn = JuliaBUGS.gen_chains(model, samples, Symbol[], []; rng=StableRNG(2024))
+
+    colnames = names(chn)
+    @test :mu in colnames
+    @test :z in colnames       # recovered marginalized latent
+    @test :pred in colnames    # deterministic generated quantity
+
+    A = Array(chn)
+    mucol = A[:, findfirst(==(:mu), colnames)]
+    zcol = A[:, findfirst(==(:z), colnames)]
+    predcol = A[:, findfirst(==(:pred), colnames)]
+
+    @test mucol ≈ [s[1] for s in samples]
+    @test predcol ≈ mucol .+ 1.0
+    @test all(z -> z in (1, 2), zcol)
+end


### PR DESCRIPTION
## Summary

- reconstruct auto-marginalized evaluation environments from continuous-only sample rows before chain post-processing
- keep `gen_chains` output consistent for continuous parameters, recovered finite discrete latents, and generated quantities
- add a regression covering auto-marginalized chain output for `mu`, recovered `z`, and deterministic generated quantity `pred`

## Why

`evaluate_with_marginalization_values!!` computed the log density from the supplied continuous sample vector, but returned an environment copied from the model's existing state. `gen_chains` then read parameter values and generated quantities from that stale environment. For auto-marginalized models, this could report stale continuous parameters and compute generated quantities from stale values.