### PR TITLE
Finalize variable-type cleanup and generated-quantity reclassification

### DIFF
--- a/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
@@ -2,11 +2,7 @@ module JuliaBUGSMCMCChainsExt
 
 using AbstractMCMC
 using JuliaBUGS
-using JuliaBUGS:
-    BUGSModel,
-    BUGSModelWithGradient,
-    evaluate!!,
-    getparams
+using JuliaBUGS: BUGSModel, BUGSModelWithGradient, evaluate!!, getparams
 using JuliaBUGS.Model: model_parameters, forward_sample_generated_quantities!!
 using JuliaBUGS.AbstractPPL
 using JuliaBUGS.Accessors

--- a/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/ext/JuliaBUGSMCMCChainsExt.jl
@@ -5,7 +5,6 @@ using JuliaBUGS
 using JuliaBUGS:
     BUGSModel,
     BUGSModelWithGradient,
-    find_generated_quantities_variables,
     evaluate!!,
     getparams
 using JuliaBUGS.Model: model_parameters, forward_sample_generated_quantities!!
@@ -133,16 +132,13 @@ function JuliaBUGS.gen_chains(
     thinning=1,
     kwargs...,
 )
-    gd = model.graph_evaluation_data
     # Report model parameters. In auto-marginalization, continuous parameters come from
     # the sample row and finite discrete latents are recovered below from p(z | theta, y).
     param_vars = model_parameters(model)
 
     # Generated quantities (no observed descendants) are reported in topological order;
     # they are disjoint from the model parameters by construction.
-    generated_vars = find_generated_quantities_variables(model.g)
-    param_set = Set(param_vars)
-    generated_vars = [v for v in gd.sorted_nodes if v in generated_vars && v ∉ param_set]
+    generated_vars = JuliaBUGS.Model.generated_quantities(model)
 
     # Evaluate model for each sample to get parameter values and generated quantities
     param_vals = []

--- a/JuliaBUGS/src/model/abstractppl.jl
+++ b/JuliaBUGS/src/model/abstractppl.jl
@@ -542,12 +542,17 @@ function _create_modified_model(
     new_evaluation_env::NamedTuple;
     base_model=nothing,
 )
-    # Create new graph evaluation data preserving the original GQ classification
-    # We must explicitly keep the original `generated_quantities` to avoid them being reclassified.
-    original_gq = Set(
+    # Preserve the base model's generated-quantity policy, but only for variables
+    # that still have no observed descendants in the modified graph. Conditioning a
+    # former generated quantity makes it an observation, so its ancestors may need
+    # to move back into the model-parameter partition.
+    base_gq = Set(
         generated_quantities(isnothing(model.base_model) ? model : model.base_model)
     )
-    new_graph_evaluation_data = GraphEvaluationData(new_graph; gq_override=original_gq)
+    surviving_gq = find_generated_quantities_variables(new_graph)
+    new_graph_evaluation_data = GraphEvaluationData(
+        new_graph; gq_override=intersect(base_gq, surviving_gq)
+    )
     new_parameters = new_graph_evaluation_data.model_parameters
 
     # Calculate new parameter lengths

--- a/JuliaBUGS/src/model/abstractppl.jl
+++ b/JuliaBUGS/src/model/abstractppl.jl
@@ -546,18 +546,21 @@ function _create_modified_model(
     # that still have no observed descendants in the modified graph. Conditioning a
     # former generated quantity makes it an observation, so its ancestors may need
     # to move back into the model-parameter partition.
-    base_gq = Set(
+    base_generated_quantities = Set(
         generated_quantities(isnothing(model.base_model) ? model : model.base_model)
     )
-    surviving_gq = find_generated_quantities_variables(new_graph)
+    surviving_generated_quantities = find_generated_quantities_variables(new_graph)
     new_graph_evaluation_data = GraphEvaluationData(
-        new_graph; gq_override=intersect(base_gq, surviving_gq)
+        new_graph;
+        generated_quantities=intersect(
+            base_generated_quantities, surviving_generated_quantities
+        ),
     )
-    new_parameters = new_graph_evaluation_data.model_parameters
+    new_model_parameters = new_graph_evaluation_data.model_parameters
 
     # Calculate new parameter lengths
     new_untransformed_param_length, new_transformed_param_length = _calculate_param_lengths(
-        model, new_parameters
+        model, new_model_parameters
     )
 
     # Recompute mutable symbols for the new graph
@@ -626,7 +629,7 @@ function _regenerate_log_density_function(
         updated_graph_evaluation_data = GraphEvaluationData(
             graph,
             sorted_nodes;
-            gq_override=Set(graph_evaluation_data.generated_quantities),
+            generated_quantities=Set(graph_evaluation_data.generated_quantities),
         )
 
         return new_log_density_computation_function, updated_graph_evaluation_data

--- a/JuliaBUGS/src/model/abstractppl.jl
+++ b/JuliaBUGS/src/model/abstractppl.jl
@@ -625,8 +625,7 @@ function _regenerate_log_density_function(
         # conditioned) graph and disagree with the generated code.
         updated_graph_evaluation_data = GraphEvaluationData(
             graph,
-            sorted_nodes,
-            graph_evaluation_data.model_parameters;
+            sorted_nodes;
             gq_override=Set(graph_evaluation_data.generated_quantities),
         )
 

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -138,8 +138,10 @@ function GraphEvaluationData(
             # descendants, but those are priors to be sampled, not generated quantities.
             # Deterministic nodes, however, are still genuine derived quantities, so keep
             # them classified as generated quantities (e.g. for reporting in chains).
-            generated_quantity_vars = Set(
-                vn for vn in generated_quantity_vars if !g[vn].is_stochastic
+            # `filter` preserves the `Set{VarName}` element type even when the result is
+            # empty, which a generator comprehension would not.
+            generated_quantity_vars = filter(
+                vn -> !g[vn].is_stochastic, generated_quantity_vars
             )
         end
     end

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -18,6 +18,7 @@ must be invalidated when the graph structure changes (e.g., during conditioning)
 - `param_lengths::Dict{VarName,Int}`: Transformed lengths for continuous parameters.
 - `param_offsets::Dict{VarName,Int}`: Start index in flattened parameter vector for each continuous param.
 - `n_discrete_finite::Int`: Number of discrete finite variables (for memo sizing).
+- `continuous_parameters::Vector{VarName}`: Continuous model parameters that remain in the flat parameter vector after marginalization.
 """
 struct MarginalizationCache{V<:VarName}
     minimal_cache_keys::Dict{Int,Vector{Int}}
@@ -26,6 +27,7 @@ struct MarginalizationCache{V<:VarName}
     param_lengths::Dict{V,Int}
     param_offsets::Dict{V,Int}
     n_discrete_finite::Int
+    continuous_parameters::Vector{V}
 end
 
 """
@@ -490,34 +492,6 @@ function initialize!(model::BUGSModel, initial_params::AbstractVector)
 end
 
 """
-    _active_parameters(model::BUGSModel)
-
-In `UseAutoMarginalization` mode, this filters out discrete variables that are being marginalized.
-Otherwise, it returns `model_parameters(model)`.
-"""
-function _active_parameters(model::BUGSModel)
-    if model.evaluation_mode isa UseAutoMarginalization
-        gd = model.graph_evaluation_data
-        mc = model.marginalization_cache
-        return filter(model_parameters(model)) do vn
-            idx = findfirst(==(vn), gd.sorted_nodes)
-            if idx !== nothing
-                node_type = mc.node_types[idx]
-                if node_type == :discrete_infinite
-                    error(
-                        "Model contains discrete infinite variable $(vn) which cannot be marginalized. " *
-                        "Use UseGraph evaluation mode instead.",
-                    )
-                end
-                return node_type == :continuous
-            end
-            return false
-        end
-    end
-    return model_parameters(model)
-end
-
-"""
     getparams([T::Type], model::BUGSModel, evaluation_env=model.evaluation_env)
 
 Extract parameter values from the model.
@@ -552,7 +526,11 @@ params_dict = getparams(Dict, model, custom_env)
 ```
 """
 function getparams(model::BUGSModel, evaluation_env=model.evaluation_env)
-    param_vars = _active_parameters(model)
+    param_vars = if model.evaluation_mode isa UseAutoMarginalization
+        model.marginalization_cache.continuous_parameters
+    else
+        model_parameters(model)
+    end
 
     # Compute total length for allocation
     param_length = 0
@@ -599,7 +577,11 @@ function getparams(
     T::Type{<:AbstractDict}, model::BUGSModel, evaluation_env=model.evaluation_env
 )
     d = T()
-    param_vars = _active_parameters(model)
+    param_vars = if model.evaluation_mode isa UseAutoMarginalization
+        model.marginalization_cache.continuous_parameters
+    else
+        model_parameters(model)
+    end
     for v in param_vars
         value = AbstractPPL.getvalue(evaluation_env, v)
         if !model.transformed
@@ -753,21 +735,38 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                 vn_to_idx = Dict(sorted_nodes[i] => i for i in eachindex(sorted_nodes))
                 param_lengths = Dict{eltype(sorted_nodes),Int}()
                 param_offsets = Dict{eltype(sorted_nodes),Int}()
+                continuous_parameters = eltype(sorted_nodes)[]
                 offset = 1
                 for vn in gd.model_parameters
                     idx = get(vn_to_idx, vn, 0)
-                    if idx != 0 && node_types[idx] == :continuous
-                        len = model.transformed_var_lengths[vn]
-                        param_lengths[vn] = len
-                        param_offsets[vn] = offset
-                        offset += len
+                    if idx != 0
+                        node_type = node_types[idx]
+                        if node_type == :discrete_infinite
+                            error(
+                                "Model contains discrete infinite variable $(vn) which cannot be marginalized. " *
+                                "Use UseGraph evaluation mode instead.",
+                            )
+                        end
+                        if node_type == :continuous
+                            len = model.transformed_var_lengths[vn]
+                            param_lengths[vn] = len
+                            param_offsets[vn] = offset
+                            offset += len
+                            push!(continuous_parameters, vn)
+                        end
                     end
                 end
 
                 n_discrete_finite = count(==(:discrete_finite), node_types)
 
                 cache = MarginalizationCache(
-                    keys, order, node_types, param_lengths, param_offsets, n_discrete_finite
+                    keys,
+                    order,
+                    node_types,
+                    param_lengths,
+                    param_offsets,
+                    n_discrete_finite,
+                    continuous_parameters,
                 )
                 model = BangBang.setproperty!!(model, :marginalization_cache, cache)
             catch err

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -134,7 +134,13 @@ function GraphEvaluationData(
         generated_quantity_vars = find_generated_quantities_variables(g)
         has_observations = any(g[vn].is_observed for vn in labels(g) if g[vn].is_stochastic)
         if !has_observations
-            generated_quantity_vars = Set{VarName}()
+            # Without observations every stochastic node trivially lacks observed
+            # descendants, but those are priors to be sampled, not generated quantities.
+            # Deterministic nodes, however, are still genuine derived quantities, so keep
+            # them classified as generated quantities (e.g. for reporting in chains).
+            generated_quantity_vars = Set(
+                vn for vn in generated_quantity_vars if !g[vn].is_stochastic
+            )
         end
     end
 

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -18,7 +18,7 @@ must be invalidated when the graph structure changes (e.g., during conditioning)
 - `param_lengths::Dict{VarName,Int}`: Transformed lengths for continuous parameters.
 - `param_offsets::Dict{VarName,Int}`: Start index in flattened parameter vector for each continuous param.
 - `n_discrete_finite::Int`: Number of discrete finite variables (for memo sizing).
-- `continuous_parameters::Vector{VarName}`: Continuous model parameters that remain in the flat parameter vector after marginalization.
+- `continuous_model_parameters::Vector{VarName}`: Continuous model parameters that remain in the flat parameter vector after marginalization.
 """
 struct MarginalizationCache{V<:VarName}
     minimal_cache_keys::Dict{Int,Vector{Int}}
@@ -27,7 +27,7 @@ struct MarginalizationCache{V<:VarName}
     param_lengths::Dict{V,Int}
     param_offsets::Dict{V,Int}
     n_discrete_finite::Int
-    continuous_parameters::Vector{V}
+    continuous_model_parameters::Vector{V}
 end
 
 """
@@ -43,11 +43,14 @@ Classification of each node in the model graph.
 @enum VariableType Observation ModelParameter TransformedParameter GeneratedQuantity
 
 @inline function _classify_variable_type(
-    vn::VarName, is_stochastic::Bool, is_observed::Bool, gq_vars::Set{<:VarName}
+    vn::VarName,
+    is_stochastic::Bool,
+    is_observed::Bool,
+    generated_quantity_vars::Set{<:VarName},
 )
     return if is_stochastic && is_observed
         Observation
-    elseif vn in gq_vars
+    elseif vn in generated_quantity_vars
         # No observed descendants
         GeneratedQuantity
     elseif is_stochastic
@@ -91,10 +94,21 @@ struct GraphEvaluationData{TNF,TV}
 end
 
 """
-    GraphEvaluationData(g::BUGSGraph, [sorted_nodes], [active_parameters])
+    GraphEvaluationData(g::BUGSGraph, [sorted_nodes], [active_parameters]; [generated_quantities])
 
 Create a `GraphEvaluationData` from a `BUGSGraph`, extracting and caching node information
 for efficient evaluation.
+
+`sorted_nodes` gives the evaluation order and defaults to the graph's topological order.
+`active_parameters`, when provided, is a filter for the parameter lists: only unobserved
+stochastic variables in that vector are added to `sorted_parameters`; non-generated
+stochastic variables outside the filter are also left out of `model_parameters`.
+
+`generated_quantities` optionally supplies the set of variables to classify as
+`GeneratedQuantity`. When it is `nothing`, the set is derived from the graph. Passing it
+is useful when rebuilding graph evaluation data after conditioning or source generation,
+where the caller needs the cached classification to match the classification used by the
+existing model.
 """
 function GraphEvaluationData(
     g::BUGSGraph,
@@ -102,7 +116,7 @@ function GraphEvaluationData(
         label_for(g, node) for node in topological_sort(g)
     ],
     active_parameters::Union{Nothing,Vector{<:VarName}}=nothing;
-    gq_override::Union{Nothing,Set{<:VarName}}=nothing,
+    generated_quantities::Union{Nothing,Set{<:VarName}}=nothing,
 )
     is_stochastic_vals = Array{Bool}(undef, length(sorted_nodes))
     is_observed_vals = Array{Bool}(undef, length(sorted_nodes))
@@ -110,17 +124,17 @@ function GraphEvaluationData(
     loop_vars_vals = Array{Any}(undef, length(sorted_nodes))
     sorted_parameters = VarName[]
     model_parameters = VarName[]
-    generated_quantities = VarName[]
+    generated_quantity_nodes = VarName[]
     variable_types = Vector{VariableType}(undef, length(sorted_nodes))
     is_model_parameter_vals = fill(false, length(sorted_nodes))
 
-    if gq_override !== nothing
-        gq_vars = gq_override
+    if generated_quantities !== nothing
+        generated_quantity_vars = generated_quantities
     else
-        gq_vars = find_generated_quantities_variables(g)
+        generated_quantity_vars = find_generated_quantities_variables(g)
         has_observations = any(g[vn].is_observed for vn in labels(g) if g[vn].is_stochastic)
         if !has_observations
-            gq_vars = Set{VarName}()
+            generated_quantity_vars = Set{VarName}()
         end
     end
 
@@ -132,11 +146,13 @@ function GraphEvaluationData(
         loop_vars_vals[i] = loop_vars
 
         # Classify each node
-        variable_types[i] = _classify_variable_type(vn, is_stochastic, is_observed, gq_vars)
+        variable_types[i] = _classify_variable_type(
+            vn, is_stochastic, is_observed, generated_quantity_vars
+        )
 
         if variable_types[i] == GeneratedQuantity
             # Both stochastic and deterministic nodes go here
-            push!(generated_quantities, vn)
+            push!(generated_quantity_nodes, vn)
             if is_stochastic && !is_observed
                 if active_parameters === nothing || vn in active_parameters
                     push!(sorted_parameters, vn)
@@ -155,7 +171,7 @@ function GraphEvaluationData(
         sorted_nodes,
         sorted_parameters,
         model_parameters,
-        generated_quantities,
+        generated_quantity_nodes,
         variable_types,
         is_model_parameter_vals,
         is_stochastic_vals,
@@ -527,7 +543,7 @@ params_dict = getparams(Dict, model, custom_env)
 """
 function getparams(model::BUGSModel, evaluation_env=model.evaluation_env)
     param_vars = if model.evaluation_mode isa UseAutoMarginalization
-        model.marginalization_cache.continuous_parameters
+        model.marginalization_cache.continuous_model_parameters
     else
         model_parameters(model)
     end
@@ -578,7 +594,7 @@ function getparams(
 )
     d = T()
     param_vars = if model.evaluation_mode isa UseAutoMarginalization
-        model.marginalization_cache.continuous_parameters
+        model.marginalization_cache.continuous_model_parameters
     else
         model_parameters(model)
     end
@@ -693,7 +709,7 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                 new_gd = GraphEvaluationData(
                     model.g,
                     sorted_nodes;
-                    gq_override=Set(model.graph_evaluation_data.generated_quantities),
+                    generated_quantities=Set(model.graph_evaluation_data.generated_quantities),
                 )
 
                 model = BangBang.setproperty!!(model, :graph_evaluation_data, new_gd)
@@ -734,7 +750,7 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                 vn_to_idx = Dict(sorted_nodes[i] => i for i in eachindex(sorted_nodes))
                 param_lengths = Dict{eltype(sorted_nodes),Int}()
                 param_offsets = Dict{eltype(sorted_nodes),Int}()
-                continuous_parameters = eltype(sorted_nodes)[]
+                continuous_model_parameters = eltype(sorted_nodes)[]
                 offset = 1
                 for vn in gd.model_parameters
                     idx = get(vn_to_idx, vn, 0)
@@ -751,7 +767,7 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                             param_lengths[vn] = len
                             param_offsets[vn] = offset
                             offset += len
-                            push!(continuous_parameters, vn)
+                            push!(continuous_model_parameters, vn)
                         end
                     end
                 end
@@ -765,7 +781,7 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                     param_lengths,
                     param_offsets,
                     n_discrete_finite,
-                    continuous_parameters,
+                    continuous_model_parameters,
                 )
                 model = BangBang.setproperty!!(model, :marginalization_cache, cache)
             catch err

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -709,7 +709,9 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                 new_gd = GraphEvaluationData(
                     model.g,
                     sorted_nodes;
-                    generated_quantities=Set(model.graph_evaluation_data.generated_quantities),
+                    generated_quantities=Set(
+                        model.graph_evaluation_data.generated_quantities
+                    ),
                 )
 
                 model = BangBang.setproperty!!(model, :graph_evaluation_data, new_gd)

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -692,8 +692,7 @@ function set_evaluation_mode(model::BUGSModel, mode::EvaluationMode)
                 # conditioned models).
                 new_gd = GraphEvaluationData(
                     model.g,
-                    sorted_nodes,
-                    model.graph_evaluation_data.model_parameters;
+                    sorted_nodes;
                     gq_override=Set(model.graph_evaluation_data.generated_quantities),
                 )
 

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -258,7 +258,7 @@ function evaluate_with_values!!(
     )
 end
 
-function _evaluate_active_parameters_with_values!!(
+function _evaluate_continuous_parameters_with_values!!(
     model::BUGSModel, flattened_values::AbstractVector; transformed=true
 )
     var_lengths = if transformed
@@ -268,7 +268,7 @@ function _evaluate_active_parameters_with_values!!(
     end
 
     evaluation_env = smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols)
-    active_parameters = Set(_active_parameters(model))
+    continuous_parameters = Set(model.marginalization_cache.continuous_parameters)
     current_idx = 1
 
     gd = model.graph_evaluation_data
@@ -281,7 +281,7 @@ function _evaluate_active_parameters_with_values!!(
         elseif !gd.is_stochastic_vals[i]
             value = node_function(evaluation_env, loop_vars)
             evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
-        elseif !gd.is_observed_vals[i] && vn in active_parameters
+        elseif !gd.is_observed_vals[i] && vn in continuous_parameters
             dist = node_function(evaluation_env, loop_vars)
             l = var_lengths[vn]
             value = if transformed
@@ -910,7 +910,7 @@ function evaluate_with_marginalization_values!!(
     memo = Dict{Tuple{Int,Tuple},Tuple{T,T}}()
     sizehint!(memo, expected_entries)
 
-    evaluation_env = _evaluate_active_parameters_with_values!!(
+    evaluation_env = _evaluate_continuous_parameters_with_values!!(
         model, flattened_values; transformed=model.transformed
     )
 

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -258,7 +258,7 @@ function evaluate_with_values!!(
     )
 end
 
-function _evaluate_continuous_parameters_with_values!!(
+function _evaluate_continuous_model_parameters_with_values!!(
     model::BUGSModel, flattened_values::AbstractVector; transformed=true
 )
     var_lengths = if transformed
@@ -268,7 +268,9 @@ function _evaluate_continuous_parameters_with_values!!(
     end
 
     evaluation_env = smart_copy_evaluation_env(model.evaluation_env, model.mutable_symbols)
-    continuous_parameters = Set(model.marginalization_cache.continuous_parameters)
+    continuous_model_parameters = Set(
+        model.marginalization_cache.continuous_model_parameters
+    )
     current_idx = 1
 
     gd = model.graph_evaluation_data
@@ -281,7 +283,7 @@ function _evaluate_continuous_parameters_with_values!!(
         elseif !gd.is_stochastic_vals[i]
             value = node_function(evaluation_env, loop_vars)
             evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
-        elseif !gd.is_observed_vals[i] && vn in continuous_parameters
+        elseif !gd.is_observed_vals[i] && vn in continuous_model_parameters
             dist = node_function(evaluation_env, loop_vars)
             l = var_lengths[vn]
             value = if transformed
@@ -910,7 +912,7 @@ function evaluate_with_marginalization_values!!(
     memo = Dict{Tuple{Int,Tuple},Tuple{T,T}}()
     sizehint!(memo, expected_entries)
 
-    evaluation_env = _evaluate_continuous_parameters_with_values!!(
+    evaluation_env = _evaluate_continuous_model_parameters_with_values!!(
         model, flattened_values; transformed=model.transformed
     )
 

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -440,8 +440,8 @@ function _backward_sample_recursive!!(
                 memo,
                 minimal_keys,
             )
-            # The continuous-prior part of branch_prior is constant across `val` and
-            # cancels in the softmax below; the rest captures all `val`-dependent terms.
+            # Keep the full branch weight: downstream prior and likelihood terms may
+            # both depend on this candidate value.
             log_weights[k] = logpdf(dist, val) + branch_prior + branch_lik
         end
         weights = exp.(log_weights .- LogExpFunctions.logsumexp(log_weights))

--- a/JuliaBUGS/src/model/logdensityproblems.jl
+++ b/JuliaBUGS/src/model/logdensityproblems.jl
@@ -30,7 +30,7 @@ function LogDensityProblems.dimension(model::BUGSModel)
     # Auto-marginalization needs the continuous-only filter; other modes can use the
     # precomputed parameter lengths (already accumulated over `model_parameters`).
     if model.evaluation_mode isa UseAutoMarginalization
-        param_vars = _active_parameters(model)
+        param_vars = model.marginalization_cache.continuous_parameters
         dim = 0
         if model.transformed
             for vn in param_vars

--- a/JuliaBUGS/src/model/logdensityproblems.jl
+++ b/JuliaBUGS/src/model/logdensityproblems.jl
@@ -30,7 +30,7 @@ function LogDensityProblems.dimension(model::BUGSModel)
     # Auto-marginalization needs the continuous-only filter; other modes can use the
     # precomputed parameter lengths (already accumulated over `model_parameters`).
     if model.evaluation_mode isa UseAutoMarginalization
-        param_vars = model.marginalization_cache.continuous_parameters
+        param_vars = model.marginalization_cache.continuous_model_parameters
         dim = 0
         if model.transformed
             for vn in param_vars

--- a/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
@@ -164,20 +164,24 @@ end
 end
 
 @testset "chains use cached generated-quantity classification" begin
+    # Even without any observations, a deterministic node has no observed descendants
+    # and is therefore a generated quantity; the stochastic node remains a model
+    # parameter. `gen_chains` reads the cached classification, so this guards against
+    # the cached generated-quantity set dropping deterministic nodes.
     model_def = @bugs begin
         x ~ dnorm(0, 1)
         pred = x + 1.0
     end
     model = compile(model_def, (;))
 
-    @test isempty(JuliaBUGS.Model.generated_quantities(model))
+    @test !isempty(JuliaBUGS.Model.generated_quantities(model))
 
     samples = [[-0.5], [0.5]]
     chn = JuliaBUGS.gen_chains(model, samples, Symbol[], []; rng=StableRNG(2024))
 
     colnames = names(chn)
     @test :x in colnames
-    @test :pred ∉ colnames
+    @test :pred in colnames
 end
 
 @testset "auto-marginalized chains reconstruct generated quantities from samples" begin

--- a/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
@@ -163,6 +163,23 @@ end
     @test mucol ≈ [s[1] for s in samples]
 end
 
+@testset "chains use cached generated-quantity classification" begin
+    model_def = @bugs begin
+        x ~ dnorm(0, 1)
+        pred = x + 1.0
+    end
+    model = compile(model_def, (;))
+
+    @test isempty(JuliaBUGS.Model.generated_quantities(model))
+
+    samples = [[-0.5], [0.5]]
+    chn = JuliaBUGS.gen_chains(model, samples, Symbol[], []; rng=StableRNG(2024))
+
+    colnames = names(chn)
+    @test :x in colnames
+    @test :pred ∉ colnames
+end
+
 @testset "auto-marginalized chains reconstruct generated quantities from samples" begin
     model_def = @bugs begin
         mu ~ Normal(0, 1)

--- a/JuliaBUGS/test/model/abstractppl.jl
+++ b/JuliaBUGS/test/model/abstractppl.jl
@@ -3,9 +3,14 @@ using JuliaBUGS
 using JuliaBUGS.Model:
     condition,
     decondition,
+    generated_quantities,
+    model_parameters,
     parameters,
     set_evaluation_mode,
     set_observed_values!,
+    variable_type,
+    ModelParameter,
+    Observation,
     regenerate_log_density_function,
     UseGeneratedLogDensityFunction,
     UseGraph
@@ -48,6 +53,36 @@ JuliaBUGS.@bugs_primitive Normal Gamma
             )
 
             @test logp1 ≈ logp2
+        end
+
+        @testset "conditioning generated quantity updates ancestor classification" begin
+            model_def = @bugs begin
+                theta ~ Normal(0, 1)
+                z ~ Normal(theta, 1)
+                y ~ Normal(0, 1)
+            end
+
+            model = compile(model_def, (; y=0.0))
+            @test isempty(model_parameters(model))
+            @test @varname(theta) in generated_quantities(model)
+            @test @varname(z) in generated_quantities(model)
+
+            model_cond = condition(model, Dict(@varname(z) => 0.5))
+            @test variable_type(model_cond, @varname(z)) == Observation
+            @test variable_type(model_cond, @varname(theta)) == ModelParameter
+            @test model_parameters(model_cond) == [@varname(theta)]
+            @test @varname(theta) ∉ generated_quantities(model_cond)
+            @test LogDensityProblems.dimension(model_cond) == 1
+
+            params = [0.25]
+            lp_graph = Base.invokelatest(LogDensityProblems.logdensity, model_cond, params)
+            model_cond_gen = set_evaluation_mode(
+                model_cond, UseGeneratedLogDensityFunction()
+            )
+            lp_gen = Base.invokelatest(
+                LogDensityProblems.logdensity, model_cond_gen, params
+            )
+            @test lp_gen ≈ lp_graph
         end
 
         @testset "Array model conditioning with correct parameter ordering" begin

--- a/JuliaBUGS/test/model/abstractppl.jl
+++ b/JuliaBUGS/test/model/abstractppl.jl
@@ -67,22 +67,24 @@ JuliaBUGS.@bugs_primitive Normal Gamma
             @test @varname(theta) in generated_quantities(model)
             @test @varname(z) in generated_quantities(model)
 
-            model_cond = condition(model, Dict(@varname(z) => 0.5))
-            @test variable_type(model_cond, @varname(z)) == Observation
-            @test variable_type(model_cond, @varname(theta)) == ModelParameter
-            @test model_parameters(model_cond) == [@varname(theta)]
-            @test @varname(theta) ∉ generated_quantities(model_cond)
-            @test LogDensityProblems.dimension(model_cond) == 1
+            conditioned_model = condition(model, Dict(@varname(z) => 0.5))
+            @test variable_type(conditioned_model, @varname(z)) == Observation
+            @test variable_type(conditioned_model, @varname(theta)) == ModelParameter
+            @test model_parameters(conditioned_model) == [@varname(theta)]
+            @test @varname(theta) ∉ generated_quantities(conditioned_model)
+            @test LogDensityProblems.dimension(conditioned_model) == 1
 
             params = [0.25]
-            lp_graph = Base.invokelatest(LogDensityProblems.logdensity, model_cond, params)
-            model_cond_gen = set_evaluation_mode(
-                model_cond, UseGeneratedLogDensityFunction()
+            graph_logdensity = Base.invokelatest(
+                LogDensityProblems.logdensity, conditioned_model, params
             )
-            lp_gen = Base.invokelatest(
-                LogDensityProblems.logdensity, model_cond_gen, params
+            generated_conditioned_model = set_evaluation_mode(
+                conditioned_model, UseGeneratedLogDensityFunction()
             )
-            @test lp_gen ≈ lp_graph
+            generated_logdensity = Base.invokelatest(
+                LogDensityProblems.logdensity, generated_conditioned_model, params
+            )
+            @test generated_logdensity ≈ graph_logdensity
         end
 
         @testset "Array model conditioning with correct parameter ordering" begin

--- a/JuliaBUGS/test/model/to_distribution.jl
+++ b/JuliaBUGS/test/model/to_distribution.jl
@@ -184,7 +184,9 @@
         @test Set(JuliaBUGS.Model.parameters(generated_model)) ==
             Set(JuliaBUGS.Model.parameters(model))
 
-        distribution = @test_logs (:warn,) match_mode = :any to_distribution(generated_model)
+        distribution = @test_logs (:warn,) match_mode = :any to_distribution(
+            generated_model
+        )
         @test distribution isa Distribution{Distributions.NamedTupleVariate{(:mu, :z)}}
 
         parameter_values = (mu=0.1, z=0.2)

--- a/JuliaBUGS/test/model/to_distribution.jl
+++ b/JuliaBUGS/test/model/to_distribution.jl
@@ -178,21 +178,22 @@
             z ~ Normal(mu, 1)
         end
         model = compile(model_def, (; y=0.5))
-        gen = JuliaBUGS.Model.set_evaluation_mode(
+        generated_model = JuliaBUGS.Model.set_evaluation_mode(
             model, JuliaBUGS.Model.UseGeneratedLogDensityFunction()
         )
-        @test Set(JuliaBUGS.Model.parameters(gen)) == Set(JuliaBUGS.Model.parameters(model))
+        @test Set(JuliaBUGS.Model.parameters(generated_model)) ==
+            Set(JuliaBUGS.Model.parameters(model))
 
-        d = @test_logs (:warn,) match_mode = :any to_distribution(gen)
-        @test d isa Distribution{Distributions.NamedTupleVariate{(:mu, :z)}}
+        distribution = @test_logs (:warn,) match_mode = :any to_distribution(generated_model)
+        @test distribution isa Distribution{Distributions.NamedTupleVariate{(:mu, :z)}}
 
-        nt = (mu=0.1, z=0.2)
-        expected =
-            logpdf(Normal(0, 1), nt.mu) +
-            logpdf(Normal(nt.mu, 1), 0.5) +
-            logpdf(Normal(nt.mu, 1), nt.z)
-        @test logpdf(d, nt) ≈ expected
-        @test_throws ArgumentError logpdf(d, (; mu=nt.mu))
+        parameter_values = (mu=0.1, z=0.2)
+        expected_logdensity =
+            logpdf(Normal(0, 1), parameter_values.mu) +
+            logpdf(Normal(parameter_values.mu, 1), 0.5) +
+            logpdf(Normal(parameter_values.mu, 1), parameter_values.z)
+        @test logpdf(distribution, parameter_values) ≈ expected_logdensity
+        @test_throws ArgumentError logpdf(distribution, (; mu=parameter_values.mu))
     end
 
     @testset "multivariate parameter nodes" begin

--- a/JuliaBUGS/test/model/to_distribution.jl
+++ b/JuliaBUGS/test/model/to_distribution.jl
@@ -171,6 +171,30 @@
         @test logpdf(d, NamedTuple()) ≈ manual
     end
 
+    @testset "generated-mode model keeps stochastic generated quantities" begin
+        model_def = @bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            z ~ Normal(mu, 1)
+        end
+        model = compile(model_def, (; y=0.5))
+        gen = JuliaBUGS.Model.set_evaluation_mode(
+            model, JuliaBUGS.Model.UseGeneratedLogDensityFunction()
+        )
+        @test Set(JuliaBUGS.Model.parameters(gen)) == Set(JuliaBUGS.Model.parameters(model))
+
+        d = @test_logs (:warn,) match_mode = :any to_distribution(gen)
+        @test d isa Distribution{Distributions.NamedTupleVariate{(:mu, :z)}}
+
+        nt = (mu=0.1, z=0.2)
+        expected =
+            logpdf(Normal(0, 1), nt.mu) +
+            logpdf(Normal(nt.mu, 1), 0.5) +
+            logpdf(Normal(nt.mu, 1), nt.z)
+        @test logpdf(d, nt) ≈ expected
+        @test_throws ArgumentError logpdf(d, (; mu=nt.mu))
+    end
+
     @testset "multivariate parameter nodes" begin
         # A single multivariate stochastic node packs into one NamedTuple field.
         @testset "ddirich (simplex-valued)" begin

--- a/JuliaBUGS/test/source_gen.jl
+++ b/JuliaBUGS/test/source_gen.jl
@@ -312,6 +312,7 @@ end
         # I1: classification and dimension do not depend on the evaluation mode.
         @test Set(JuliaBUGS.model_parameters(m_gen)) == mp
         @test Set(JuliaBUGS.generated_quantities(m_gen)) == gq
+        @test Set(JuliaBUGS.parameters(m_gen)) == allpar
         @test LogDensityProblems.dimension(m_gen) == dim
 
         # Per-model anchors so a silent reclassification can't pass unnoticed.

--- a/JuliaBUGS/test/source_gen.jl
+++ b/JuliaBUGS/test/source_gen.jl
@@ -292,57 +292,62 @@ end
     #       both `getparams` and the log density unchanged, in both modes.
     JuliaBUGS.@bugs_primitive Normal
 
-    fsgq = JuliaBUGS.Model.forward_sample_generated_quantities!!
+    forward_sample_generated_quantities =
+        JuliaBUGS.Model.forward_sample_generated_quantities!!
 
     # `n_params` is the number of (scalar) model parameters = the expected `dimension`;
     # `n_gq` the number of generated-quantity nodes; `has_stochastic_gq` whether at least
     # one GQ is stochastic (so re-sampling actually perturbs the environment).
     function check_gq_invariants(model; n_params, n_gq, has_stochastic_gq)
-        m_graph = JuliaBUGS.set_evaluation_mode(model, JuliaBUGS.UseGraph())
-        m_gen = JuliaBUGS.set_evaluation_mode(
+        graph_model = JuliaBUGS.set_evaluation_mode(model, JuliaBUGS.UseGraph())
+        generated_model = JuliaBUGS.set_evaluation_mode(
             model, JuliaBUGS.UseGeneratedLogDensityFunction()
         )
-        @test !isnothing(m_gen.log_density_computation_function)
+        @test !isnothing(generated_model.log_density_computation_function)
 
-        mp = Set(JuliaBUGS.model_parameters(m_graph))
-        gq = Set(JuliaBUGS.generated_quantities(m_graph))
-        allpar = Set(JuliaBUGS.parameters(m_graph))
-        dim = LogDensityProblems.dimension(m_graph)
+        model_parameter_set = Set(JuliaBUGS.model_parameters(graph_model))
+        generated_quantity_set = Set(JuliaBUGS.generated_quantities(graph_model))
+        parameter_set = Set(JuliaBUGS.parameters(graph_model))
+        dimension = LogDensityProblems.dimension(graph_model)
 
         # I1: classification and dimension do not depend on the evaluation mode.
-        @test Set(JuliaBUGS.model_parameters(m_gen)) == mp
-        @test Set(JuliaBUGS.generated_quantities(m_gen)) == gq
-        @test Set(JuliaBUGS.parameters(m_gen)) == allpar
-        @test LogDensityProblems.dimension(m_gen) == dim
+        @test Set(JuliaBUGS.model_parameters(generated_model)) == model_parameter_set
+        @test Set(JuliaBUGS.generated_quantities(generated_model)) == generated_quantity_set
+        @test Set(JuliaBUGS.parameters(generated_model)) == parameter_set
+        @test LogDensityProblems.dimension(generated_model) == dimension
 
         # Per-model anchors so a silent reclassification can't pass unnoticed.
-        @test length(mp) == n_params
-        @test length(gq) == n_gq
-        @test dim == n_params
+        @test length(model_parameter_set) == n_params
+        @test length(generated_quantity_set) == n_gq
+        @test dimension == n_params
 
         # I2: model parameters and generated quantities partition the unobserved
         # stochastic nodes; `parameters` is their union (it also lists stochastic GQ).
-        @test isempty(intersect(mp, gq))
-        @test issubset(mp, allpar)
-        @test issubset(allpar, union(mp, gq))
+        @test isempty(intersect(model_parameter_set, generated_quantity_set))
+        @test issubset(model_parameter_set, parameter_set)
+        @test issubset(parameter_set, union(model_parameter_set, generated_quantity_set))
 
         # I3: the parameter vector covers exactly the model parameters; no GQ leaks in.
-        @test length(JuliaBUGS.getparams(m_graph)) == dim
-        param_keys = Set(keys(JuliaBUGS.getparams(Dict, m_graph)))
-        @test param_keys == mp
-        @test isempty(intersect(param_keys, gq))
+        @test length(JuliaBUGS.getparams(graph_model)) == dimension
+        param_keys = Set(keys(JuliaBUGS.getparams(Dict, graph_model)))
+        @test param_keys == model_parameter_set
+        @test isempty(intersect(param_keys, generated_quantity_set))
 
         # I4: generated log density matches graph evaluation at matched values.
         for seed in 1:8
             env, _ = Base.invokelatest(
                 JuliaBUGS.AbstractPPL.evaluate!!, Random.MersenneTwister(seed), model
             )
-            xg = JuliaBUGS.getparams(m_graph, env)
-            xgen = JuliaBUGS.getparams(m_gen, env)
-            @test length(xg) == length(xgen) == dim
-            lp_graph = Base.invokelatest(LogDensityProblems.logdensity, m_graph, xg)
-            lp_gen = Base.invokelatest(LogDensityProblems.logdensity, m_gen, xgen)
-            @test isapprox(lp_graph, lp_gen; atol=1e-10)
+            graph_parameters = JuliaBUGS.getparams(graph_model, env)
+            generated_parameters = JuliaBUGS.getparams(generated_model, env)
+            @test length(graph_parameters) == length(generated_parameters) == dimension
+            graph_logdensity = Base.invokelatest(
+                LogDensityProblems.logdensity, graph_model, graph_parameters
+            )
+            generated_logdensity = Base.invokelatest(
+                LogDensityProblems.logdensity, generated_model, generated_parameters
+            )
+            @test isapprox(graph_logdensity, generated_logdensity; atol=1e-10)
         end
 
         # I5: log density is invariant to the values of generated quantities. Two forward
@@ -350,25 +355,32 @@ end
         base_env, _ = Base.invokelatest(
             JuliaBUGS.AbstractPPL.evaluate!!, Random.MersenneTwister(99), model
         )
-        # `fsgq` calls the compiled node functions directly, so invoke it in the latest
+        # This helper calls the compiled node functions directly, so invoke it in the latest
         # world age (the helper is defined before these models are compiled).
         env_a = Base.invokelatest(
-            fsgq, Random.MersenneTwister(1), model, deepcopy(base_env)
+            forward_sample_generated_quantities,
+            Random.MersenneTwister(1),
+            model,
+            deepcopy(base_env),
         )
         env_b = Base.invokelatest(
-            fsgq, Random.MersenneTwister(2), model, deepcopy(base_env)
+            forward_sample_generated_quantities,
+            Random.MersenneTwister(2),
+            model,
+            deepcopy(base_env),
         )
-        @test JuliaBUGS.getparams(m_graph, env_a) == JuliaBUGS.getparams(m_graph, env_b)
+        @test JuliaBUGS.getparams(graph_model, env_a) ==
+            JuliaBUGS.getparams(graph_model, env_b)
         if has_stochastic_gq
             # Guard against a vacuous test: the GQ values really did change.
             @test any(
                 vn ->
                     JuliaBUGS.AbstractPPL.getvalue(env_a, vn) !=
                     JuliaBUGS.AbstractPPL.getvalue(env_b, vn),
-                gq,
+                generated_quantity_set,
             )
         end
-        for m in (m_graph, m_gen)
+        for m in (graph_model, generated_model)
             m_a = BangBang.setproperty!!(m, :evaluation_env, env_a)
             m_b = BangBang.setproperty!!(m, :evaluation_env, env_b)
             lp_a = Base.invokelatest(
@@ -475,8 +487,12 @@ end
                 y[i] ~ Normal(x[i], 1)
             end
         end), (;))
-        model_cond = condition(model, Dict(@varname(x[1]) => 0.5, @varname(x[3]) => 1.5))
-        check_gq_invariants(model_cond; n_params=4, n_gq=0, has_stochastic_gq=false)
+        conditioned_model = condition(
+            model, Dict(@varname(x[1]) => 0.5, @varname(x[3]) => 1.5)
+        )
+        check_gq_invariants(
+            conditioned_model; n_params=4, n_gq=0, has_stochastic_gq=false
+        )
     end
 
     @testset "conditioning preserves a surviving generated quantity" begin
@@ -488,7 +504,9 @@ end
             y ~ Normal(mu, 1)
             z ~ Normal(mu, 1)
         end), (; y=0.5))
-        model_cond = condition(model, Dict(@varname(mu) => 0.3))
-        check_gq_invariants(model_cond; n_params=0, n_gq=1, has_stochastic_gq=true)
+        conditioned_model = condition(model, Dict(@varname(mu) => 0.3))
+        check_gq_invariants(
+            conditioned_model; n_params=0, n_gq=1, has_stochastic_gq=true
+        )
     end
 end

--- a/JuliaBUGS/test/source_gen.jl
+++ b/JuliaBUGS/test/source_gen.jl
@@ -490,9 +490,7 @@ end
         conditioned_model = condition(
             model, Dict(@varname(x[1]) => 0.5, @varname(x[3]) => 1.5)
         )
-        check_gq_invariants(
-            conditioned_model; n_params=4, n_gq=0, has_stochastic_gq=false
-        )
+        check_gq_invariants(conditioned_model; n_params=4, n_gq=0, has_stochastic_gq=false)
     end
 
     @testset "conditioning preserves a surviving generated quantity" begin
@@ -505,8 +503,6 @@ end
             z ~ Normal(mu, 1)
         end), (; y=0.5))
         conditioned_model = condition(model, Dict(@varname(mu) => 0.3))
-        check_gq_invariants(
-            conditioned_model; n_params=0, n_gq=1, has_stochastic_gq=true
-        )
+        check_gq_invariants(conditioned_model; n_params=0, n_gq=1, has_stochastic_gq=true)
     end
 end


### PR DESCRIPTION
Stacked on top of #501 (base branch `variabletype_enum`). This finalizes the
variable-type classification cleanup and fixes a few correctness/naming issues
that surfaced while wiring up generated quantities and auto-marginalization.

## Changes

- **Reclassify generated quantities after conditioning.** When a former
  generated quantity is conditioned it becomes an observation, so its ancestors
  may need to move back into the model-parameter partition.
  `_create_modified_model` now preserves the base model's GQ policy only for
  variables that still have no observed descendants in the modified graph.

- **Rename `gq_override` → `generated_quantities`** on `GraphEvaluationData`, plus
  internal `gq_vars` → `generated_quantity_vars` and `generated_quantities` (the
  local accumulator) → `generated_quantity_nodes`, with expanded docstrings
  explaining when callers should supply the classification explicitly.

- **Cache continuous marginalization parameters.** `MarginalizationCache` now
  stores `continuous_model_parameters`, computed once in `set_evaluation_mode`.
  This replaces the per-call `_active_parameters` helper used by `getparams` and
  marginalized evaluation, and moves the discrete-infinite error to cache build
  time.

- **Preserve generated quantities in generated mode** and **use the cached
  generated quantities in chains** (`JuliaBUGSMCMCChainsExt`).

- **Backward sampling weight fix.** Keep the full branch weight when scoring
  candidate values; the continuous-prior term does not always cancel in the
  softmax because downstream prior and likelihood terms can both depend on the
  candidate.

## Tests

Adds coverage in `test/model/abstractppl.jl`, `test/model/to_distribution.jl`,
`test/ext/JuliaBUGSMCMCChainsExt.jl`, and updates `test/source_gen.jl`.
