### PR TITLE
Fix generated-quantity target closure

### DIFF
--- a/JuliaBUGS/docs/src/inference/generated_quantities.md
+++ b/JuliaBUGS/docs/src/inference/generated_quantities.md
@@ -1,10 +1,11 @@
 # Generated Quantities
 
-A **generated quantity** is an unobserved node — stochastic or deterministic — that has
-**no observed descendants**: no directed path leads from it to any observation. Because it
-cannot influence the likelihood, it contributes nothing to the posterior over the model
-parameters. JuliaBUGS therefore keeps generated quantities *out of the inference target* and
-recovers them afterwards by forward sampling.
+A **generated quantity** is an unobserved node — stochastic or deterministic — that is
+outside the log-density target dependency closure. In a model with observations, this usually
+means the node has **no observed descendants**: no directed path leads from it to any
+observation. Because it cannot influence the target density over the model parameters,
+JuliaBUGS keeps generated quantities *out of the inference target* and recovers them
+afterwards by forward sampling.
 
 Typical generated quantities are posterior-predictive draws, derived summaries, or latent
 states you want to report but not sample directly:
@@ -27,9 +28,10 @@ generated quantities.
 Every node is assigned a [`VariableType`](@ref JuliaBUGS.VariableType): `Observation`, `ModelParameter`,
 `TransformedParameter`, or `GeneratedQuantity`. The partition that matters for inference is:
 
-- **Model parameters** — unobserved stochastic nodes that influence an observation. These are
-  what MCMC samples; they make up the parameter vector and the dimension.
-- **Generated quantities** — unobserved nodes with no observed descendants.
+- **Model parameters** — unobserved stochastic nodes in the target. These are what MCMC
+  samples; they make up the parameter vector and the dimension.
+- **Transformed parameters** — deterministic nodes needed to evaluate the target density.
+- **Generated quantities** — unobserved nodes outside the target dependency closure.
 
 The two sets are disjoint, and no model parameter or observation ever has a generated
 quantity as an ancestor.
@@ -91,11 +93,28 @@ are unaffected.
 
 ## Models with no observations
 
-The classification depends on a model having at least one observation. If a model has **no**
-observations at all, JuliaBUGS does *not* treat every node as a generated quantity (which
-would leave nothing to sample); instead all unobserved stochastic nodes are kept as model
-parameters, so the model is sampled as the full prior. Add data (or `condition` on some
-variables) to obtain a non-trivial generated-quantity partition.
+If a model has **no** observations at all, JuliaBUGS does *not* treat every node as a
+generated quantity (which would leave nothing to sample). Instead all unobserved stochastic
+nodes are kept as model parameters, so the model is sampled as the full prior. Deterministic
+ancestors of those stochastic parameters are transformed parameters and are recomputed during
+log-density evaluation. Terminal deterministic nodes that do not feed any stochastic factor
+can still be generated quantities.
+
+For example, in this prior-only model `h` is **not** a generated quantity because the prior
+factor for `y` depends on it:
+
+```julia
+model_def = @bugs begin
+    x ~ Normal(0, 1)
+    h = x + 1
+    y ~ Normal(h, 1)
+end
+model = compile(model_def, (;))
+JuliaBUGS.variable_type(model, @varname(h))  # TransformedParameter
+```
+
+Add data (or `condition` on some variables) to obtain the usual observed-data
+generated-quantity partition.
 
 ## API
 

--- a/JuliaBUGS/src/model/abstractmcmc.jl
+++ b/JuliaBUGS/src/model/abstractmcmc.jl
@@ -11,12 +11,17 @@ function AbstractMCMC.ParamsWithStats(
 )
     bugs_model = model.logdensity
 
-    param_vars = model_parameters(bugs_model)
+    transition_env = merge(bugs_model.evaluation_env, transition)
+    param_vars = if bugs_model.evaluation_mode isa UseAutoMarginalization
+        bugs_model.marginalization_cache.continuous_model_parameters
+    else
+        model_parameters(bugs_model)
+    end
 
     p = if params
         d = OrderedDict{String,Any}()
         for vn in param_vars
-            value = AbstractPPL.getvalue(transition, vn)
+            value = AbstractPPL.getvalue(transition_env, vn)
             d[string(vn)] = value
         end
         [k => v for (k, v) in d]
@@ -25,10 +30,16 @@ function AbstractMCMC.ParamsWithStats(
     end
 
     s = if stats
-        model_with_env = BangBang.setproperty!!(bugs_model, :evaluation_env, transition)
-        _, log_densities = evaluate_with_env!!(
-            model_with_env; transformed=bugs_model.transformed
-        )
+        log_densities = if bugs_model.evaluation_mode isa UseAutoMarginalization
+            _, lds = evaluate_with_marginalization_values!!(
+                bugs_model, getparams(bugs_model, transition_env)
+            )
+            lds
+        else
+            model_with_env = BangBang.setproperty!!(bugs_model, :evaluation_env, transition_env)
+            _, lds = evaluate_with_env!!(model_with_env; transformed=bugs_model.transformed)
+            lds
+        end
         (lp=log_densities.tempered_logjoint,)
     else
         NamedTuple()

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -38,7 +38,8 @@ Classification of each node in the model graph.
 - `Observation`: a stochastic node with observed data
 - `ModelParameter`: a stochastic node that influences observations (sampled by MCMC)
 - `TransformedParameter`: a deterministic node that needs to be computed during each iteration of sampling
-- `GeneratedQuantity`: a stochastic or deterministic node with no observed descendants (computed after getting samples)
+- `GeneratedQuantity`: a stochastic or deterministic node outside the log-density target
+  closure (computed after getting samples)
 """
 @enum VariableType Observation ModelParameter TransformedParameter GeneratedQuantity
 
@@ -51,7 +52,7 @@ Classification of each node in the model graph.
     return if is_stochastic && is_observed
         Observation
     elseif vn in generated_quantity_vars
-        # No observed descendants
+        # Outside the log-density target closure.
         GeneratedQuantity
     elseif is_stochastic
         # Stochastic node that influences observed likelihood terms.
@@ -60,6 +61,24 @@ Classification of each node in the model graph.
         # Deterministic node needed during each sampling iteration.
         TransformedParameter
     end
+end
+
+function _can_reach_stochastic(
+    g::BUGSGraph, vn::VarName, can_reach_stochastic::Dict{VarName,Bool}
+)
+    if haskey(can_reach_stochastic, vn)
+        return can_reach_stochastic[vn]
+    end
+
+    for child in MetaGraphsNext.outneighbor_labels(g, vn)
+        if g[child].is_stochastic || _can_reach_stochastic(g, child, can_reach_stochastic)
+            can_reach_stochastic[vn] = true
+            return true
+        end
+    end
+
+    can_reach_stochastic[vn] = false
+    return false
 end
 
 """
@@ -72,7 +91,7 @@ Stores pre-computed values to avoid repeated lookups from the MetaGraph during m
 - `sorted_nodes::Vector{<:VarName}`: Variables in topological order for evaluation
 - `sorted_parameters::Vector{<:VarName}`: Parameters (unobserved stochastic variables) in sorted order consistent with sorted_nodes
 - `model_parameters::Vector{<:VarName}`: Unobserved stochastic variables that influence observations
-- `generated_quantities::Vector{<:VarName}`: Variables (stochastic or deterministic) with no observed descendants
+- `generated_quantities::Vector{<:VarName}`: Variables (stochastic or deterministic) outside the log-density target closure
 - `variable_types::Vector{VariableType}`: Classification of each node
 - `is_model_parameter_vals::Vector{Bool}`: Whether each node is part of the MCMC parameter vector (true exactly for `model_parameters`)
 - `is_stochastic_vals::Vector{Bool}`: Whether each node represents a stochastic variable
@@ -136,12 +155,17 @@ function GraphEvaluationData(
         if !has_observations
             # Without observations every stochastic node trivially lacks observed
             # descendants, but those are priors to be sampled, not generated quantities.
-            # Deterministic nodes, however, are still genuine derived quantities, so keep
-            # them classified as generated quantities (e.g. for reporting in chains).
+            # Deterministic ancestors of those stochastic parameters are needed by the
+            # target and must be recomputed during log-density evaluation; only purely
+            # terminal deterministic derived quantities remain generated quantities.
             # `filter` preserves the `Set{VarName}` element type even when the result is
             # empty, which a generator comprehension would not.
+            can_reach_stochastic = Dict{VarName,Bool}()
             generated_quantity_vars = filter(
-                vn -> !g[vn].is_stochastic, generated_quantity_vars
+                vn ->
+                    !g[vn].is_stochastic &&
+                    !_can_reach_stochastic(g, vn, can_reach_stochastic),
+                generated_quantity_vars,
             )
         end
     end
@@ -438,7 +462,8 @@ model_parameters(model::BUGSModel) = model.graph_evaluation_data.model_parameter
 """
     generated_quantities(model::BUGSModel)
 
-Return a vector of `VarName` containing variables with no observed descendants. These can be computed after getting samples.
+Return a vector of `VarName` containing variables outside the log-density target
+closure. These can be computed after getting samples.
 """
 generated_quantities(model::BUGSModel) = model.graph_evaluation_data.generated_quantities
 

--- a/JuliaBUGS/src/model/evaluation.jl
+++ b/JuliaBUGS/src/model/evaluation.jl
@@ -80,21 +80,25 @@ function evaluate_with_rng!!(
                 value = rand(rng, dist)
             end
 
-            if transformed
-                value_transformed = Bijectors.transform(Bijectors.bijector(dist), value)
-                logp =
+            should_score =
+                is_observed ||
+                include_generated_quantities ||
+                model.graph_evaluation_data.is_model_parameter_vals[i]
+            if should_score
+                logp = if transformed
+                    value_transformed = Bijectors.transform(Bijectors.bijector(dist), value)
                     Distributions.logpdf(dist, value) + Bijectors.logabsdetjac(
                         Bijectors.inverse(Bijectors.bijector(dist)), value_transformed
                     )
-            else
-                logp = Distributions.logpdf(dist, value)
-            end
+                else
+                    Distributions.logpdf(dist, value)
+                end
 
-            if is_observed
-                loglikelihood += logp
-            elseif include_generated_quantities ||
-                model.graph_evaluation_data.is_model_parameter_vals[i]
-                logprior += logp
+                if is_observed
+                    loglikelihood += logp
+                else
+                    logprior += logp
+                end
             end
 
             evaluation_env = setindex!!(evaluation_env, value, vn)
@@ -144,7 +148,10 @@ function evaluate_with_env!!(
         node_function = model.graph_evaluation_data.node_function_vals[i]
         loop_vars = model.graph_evaluation_data.loop_vars_vals[i]
 
-        if !is_stochastic
+        if model.graph_evaluation_data.variable_types[i] == GeneratedQuantity &&
+            !include_generated_quantities
+            continue
+        elseif !is_stochastic
             value = node_function(evaluation_env, loop_vars)
             evaluation_env = setindex!!(evaluation_env, value, vn)
         else
@@ -218,7 +225,9 @@ function evaluate_with_values!!(
         is_observed = model.graph_evaluation_data.is_observed_vals[i]
         node_function = model.graph_evaluation_data.node_function_vals[i]
         loop_vars = model.graph_evaluation_data.loop_vars_vals[i]
-        if !is_stochastic
+        if model.graph_evaluation_data.variable_types[i] == GeneratedQuantity
+            continue
+        elseif !is_stochastic
             value = node_function(evaluation_env, loop_vars)
             evaluation_env = BangBang.setindex!!(evaluation_env, value, vn)
         elseif !is_observed && model.graph_evaluation_data.is_model_parameter_vals[i]
@@ -315,11 +324,11 @@ end
 Forward-sample the generated quantities of `model` given an environment that already holds
 the model parameters, observations, and transformed parameters.
 
-Generated quantities are the nodes with no observed descendants. Stochastic ones are drawn
-from their conditional distribution given their (already-set) parents (`rand`); deterministic
-ones are recomputed. Model parameters, observations, and transformed parameters are left
-untouched. Nodes are visited in topological order, so chains of generated quantities are
-sampled with their parents already in place.
+Generated quantities are the nodes outside the log-density target dependency closure.
+Stochastic ones are drawn from their conditional distribution given their (already-set)
+parents (`rand`); deterministic ones are recomputed. Model parameters, observations, and
+transformed parameters are left untouched. Nodes are visited in topological order, so chains
+of generated quantities are sampled with their parents already in place.
 
 If `model` is in `UseAutoMarginalization` mode its discrete latents were summed out of the
 log density and have no value in `evaluation_env`. A generated quantity may depend on such a
@@ -750,7 +759,7 @@ function _marginalize_recursive(
     rest_indices = @view(remaining_indices[2:end])
 
     result = if gd.variable_types[current_idx] == GeneratedQuantity
-        # Generated quantities have no observed descendants, so the whole generated-quantity
+        # Generated quantities are outside the target closure, so the generated-quantity
         # block integrates/sums to one and factors out of the marginalized target p(θ, y).
         # Skip it entirely: don't read the parameter vector (it has no slot there) and don't
         # marginalize it. They are recovered later by forward sampling, not here.

--- a/JuliaBUGS/src/source_gen.jl
+++ b/JuliaBUGS/src/source_gen.jl
@@ -424,7 +424,7 @@ function _generate_lowered_model_def(
     g::JuliaBUGS.BUGSGraph,
     evaluation_env::NamedTuple;
     diagnostics::Vector{String}=String[],
-    generated_quantities::Set{<:VarName}=Set{VarName}(),
+    generated_quantities::Union{Nothing,Set{<:VarName}}=nothing,
 )
     __check_for_reserved_names(model_def)
     stmt_to_stmt_id = _build_stmt_to_stmt_id(model_def)
@@ -488,8 +488,17 @@ function _generate_lowered_model_def(
         sorted_fissioned_stmts
     )
     induction_variable_values = _var_to_loop_vars(model_def, evaluation_env)
+    generated_quantity_vars = if generated_quantities === nothing
+        Set(Model.GraphEvaluationData(g).generated_quantities)
+    else
+        generated_quantities
+    end
     var_types = __determine_var_types(
-        g, stmt_id_to_var, stmt_id_to_stmt, induction_variable_values, generated_quantities
+        g,
+        stmt_id_to_var,
+        stmt_id_to_stmt,
+        induction_variable_values,
+        generated_quantity_vars,
     )
     lowered_model_def = _lower_model_def_to_represent_observe_stmts(
         reconstructed_model_def, stmt_to_stmt_id, var_types, evaluation_env
@@ -596,8 +605,9 @@ function __variable_type(g::JuliaBUGS.BUGSGraph, var, generated_quantities)
     if g[var].is_stochastic && g[var].is_observed
         return :observed
     elseif var in generated_quantities
-        # No observed descendants: stochastic ones are forward-sampled and deterministic
-        # ones are recomputed in post-processing, so neither belongs in the log density.
+        # Outside the target closure: stochastic ones are forward-sampled and
+        # deterministic ones are recomputed in post-processing, so neither belongs in
+        # the log density.
         return :generated_quantity
     elseif g[var].is_stochastic
         return :model_parameter

--- a/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSMCMCChainsExt.jl
@@ -164,10 +164,10 @@ end
 end
 
 @testset "chains use cached generated-quantity classification" begin
-    # Even without any observations, a deterministic node has no observed descendants
-    # and is therefore a generated quantity; the stochastic node remains a model
+    # Even without any observations, a terminal deterministic node that feeds no
+    # stochastic factor is a generated quantity; the stochastic node remains a model
     # parameter. `gen_chains` reads the cached classification, so this guards against
-    # the cached generated-quantity set dropping deterministic nodes.
+    # the cached generated-quantity set dropping terminal deterministic nodes.
     model_def = @bugs begin
         x ~ dnorm(0, 1)
         pred = x + 1.0

--- a/JuliaBUGS/test/model/abstractmcmc.jl
+++ b/JuliaBUGS/test/model/abstractmcmc.jl
@@ -81,4 +81,32 @@ using Test
         @test length(collected) == 3
         @test all(c -> haskey(c, :mu), collected)
     end
+
+    @testset "ParamsWithStats with auto-marginalization reports flat parameters" begin
+        model_def = @bugs begin
+            mu ~ Normal(0, 1)
+            z ~ Categorical(w[1:K])
+            y ~ Normal(mu + delta[z], sigma)
+        end
+
+        model = compile(model_def, (K=2, w=[0.3, 0.7], delta=[0.0, 2.0], sigma=1.0, y=1.5))
+        model = JuliaBUGS.settrans(model, true)
+        model = JuliaBUGS.set_evaluation_mode(model, JuliaBUGS.UseAutoMarginalization())
+        transition, log_densities = JuliaBUGS.Model.evaluate_with_marginalization_values!!(
+            model, [0.0]
+        )
+
+        pws = AbstractMCMC.ParamsWithStats(
+            AbstractMCMC.LogDensityModel(model),
+            sampler,
+            transition,
+            state;
+            params=true,
+            stats=true,
+        )
+
+        @test haskey(pws.params, :mu)
+        @test !haskey(pws.params, :z)
+        @test pws.stats.lp ≈ log_densities.tempered_logjoint
+    end
 end

--- a/JuliaBUGS/test/model/evaluation.jl
+++ b/JuliaBUGS/test/model/evaluation.jl
@@ -426,6 +426,27 @@ end
         @test log_densities.logprior ≈ expected_logprior
         @test log_densities.loglikelihood ≈ expected_loglikelihood
     end
+
+    @testset "Excluded generated quantities are not evaluated" begin
+        model_def = @bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            z ~ Exponential(1)
+            w ~ Gamma(z, 1)
+        end
+
+        model = compile(model_def, (; y=0.0))
+        stale_env = JuliaBUGS.BangBang.setindex!!(model.evaluation_env, -1.0, @varname(z))
+
+        _, ld_excl = JuliaBUGS.evaluate_with_env!!(
+            model, stale_env; include_generated_quantities=false
+        )
+        @test isfinite(ld_excl.tempered_logjoint)
+
+        @test_throws DomainError JuliaBUGS.evaluate_with_env!!(
+            model, stale_env; include_generated_quantities=true
+        )
+    end
 end
 
 @testset "evaluate_with_values!!" begin

--- a/JuliaBUGS/test/source_gen.jl
+++ b/JuliaBUGS/test/source_gen.jl
@@ -409,6 +409,46 @@ end
         )
     end
 
+    @testset "_generate_lowered_model_def derives GQ classification by default" begin
+        model = compile((@bugs begin
+            mu ~ Normal(0, 1)
+            y ~ Normal(mu, 1)
+            z ~ Normal(mu, 1)
+            pred = mu + 1.0
+        end), (; y=0.5))
+
+        lowered_default, _ = JuliaBUGS._generate_lowered_model_def(
+            model.model_def, model.g, model.evaluation_env
+        )
+        lowered_cached, _ = JuliaBUGS._generate_lowered_model_def(
+            model.model_def,
+            model.g,
+            model.evaluation_env;
+            generated_quantities=Set(JuliaBUGS.generated_quantities(model)),
+        )
+        @test lowered_default == lowered_cached
+    end
+
+    @testset "prior-only deterministic ancestor of stochastic parameter" begin
+        model = compile((@bugs begin
+            x ~ Normal(0, 1)
+            h = x + 1
+            y ~ Normal(h, 1)
+        end), (;))
+
+        @test JuliaBUGS.variable_type(model, @varname(h)) == JuliaBUGS.TransformedParameter
+        check_gq_invariants(model; n_params=2, n_gq=0, has_stochastic_gq=false)
+
+        graph_model = JuliaBUGS.set_evaluation_mode(model, JuliaBUGS.UseGraph())
+        generated_model = JuliaBUGS.set_evaluation_mode(
+            model, JuliaBUGS.UseGeneratedLogDensityFunction()
+        )
+        for values in ([0.0, 0.0], [1.0, 2.0], [-2.0, 0.5])
+            @test LogDensityProblems.logdensity(graph_model, values) ≈
+                LogDensityProblems.logdensity(generated_model, values)
+        end
+    end
+
     @testset "chained GQ" begin
         # z and z2 form a GQ chain hanging off mu.
         check_gq_invariants(


### PR DESCRIPTION
## Summary

- Reclassify prior-only deterministic ancestors of stochastic parameters as transformed parameters so generated source recomputes them.
- Make source generation derive the cached generated-quantity classification by default.
- Skip excluded generated quantities before graph/env logpdf work and align auto-marginalized ParamsWithStats with the continuous flat parameter vector.
- Update generated-quantity docs and add focused regressions.

## Why

PR #501 introduced a mismatch where prior-only deterministic ancestors could be classified as generated quantities and dropped from generated log-density source, leaving stale environment values in the target. The generated-quantity rule now follows the log-density target dependency closure instead.

