### PR TITLE
Optimize mixed generated-quantity source guards

### DIFF
--- a/JuliaBUGS/src/source_gen.jl
+++ b/JuliaBUGS/src/source_gen.jl
@@ -346,9 +346,9 @@ end
 
 # Lower a statement that has generated-quantity iterations. Generated quantities never
 # contribute to the log density (stochastic ones are forward-sampled, deterministic ones
-# recomputed, in post-processing), so the emitted code guards the surviving categories
-# with explicit per-iteration conditions and lets generated-quantity iterations fall
-# through. Returns `nothing` when the whole statement is generated quantities.
+# recomputed, in post-processing), so the emitted code uses loop-index guards for
+# the surviving categories and lets generated-quantity iterations fall through. Returns
+# `nothing` when the whole statement is generated quantities.
 function __lower_stmt_with_generated_quantities(
     statement, observed_loop_vars, model_parameter_loop_vars, deterministic_loop_vars
 )

--- a/JuliaBUGS/src/source_gen.jl
+++ b/JuliaBUGS/src/source_gen.jl
@@ -259,29 +259,40 @@ function _lower_model_def_to_represent_observe_stmts(
             _contains_generated_quantity = !isempty(generated_quantity_loop_vars)
 
             if _contains_generated_quantity
-                # Generated-quantity iterations are forward-sampled in post-processing and
-                # must not enter the log density. Emit code only for the model-parameter,
-                # observed, and kept-deterministic iterations; generated-quantity
-                # iterations fall through. A statement that is entirely generated
-                # quantities is dropped.
+                # Generated quantities are outside the target closure. Lower only the
+                # iterations that contribute to, or are needed by, the log density.
                 new_stmt = __lower_stmt_with_generated_quantities(
                     statement,
                     observed_loop_vars,
                     model_parameter_loop_vars,
+                    generated_quantity_loop_vars,
                     deterministic_loop_vars,
                 )
                 isnothing(new_stmt) || push!(lowered_model_def.args, new_stmt)
             elseif _contains_observed
                 if _contains_model_parameter
                     MacroTools.@capture(statement, lhs_ ~ rhs_)
-                    new_stmt = MacroTools.@q if condition_placeholder
-                        $(lhs) ~ $(rhs)
+                    tilde_stmt = MacroTools.@q $(lhs) ~ $(rhs)
+                    observe_stmt = MacroTools.@q $(lhs) ≂ $(rhs)
+                    # Use the shorter condition; the complementary iterations take the
+                    # else branch while loop order preserves parameter consumption.
+                    if length(observed_loop_vars) < length(model_parameter_loop_vars)
+                        new_stmt = Expr(
+                            :if,
+                            __generate_model_parameter_condition_expr(observed_loop_vars),
+                            Expr(:block, observe_stmt),
+                            Expr(:block, tilde_stmt),
+                        )
                     else
-                        $(lhs) ≂ $(rhs)
+                        new_stmt = Expr(
+                            :if,
+                            __generate_model_parameter_condition_expr(
+                                model_parameter_loop_vars
+                            ),
+                            Expr(:block, tilde_stmt),
+                            Expr(:block, observe_stmt),
+                        )
                     end
-                    new_stmt.args[1] = __generate_model_parameter_condition_expr(
-                        model_parameter_loop_vars
-                    )
                     push!(lowered_model_def.args, new_stmt)
                 else
                     MacroTools.@capture(statement, lhs_ ~ rhs_)
@@ -344,13 +355,24 @@ function __generate_model_parameter_condition_expr(model_param_nt_vec)
     end
 end
 
-# Lower a statement that has generated-quantity iterations. Generated quantities never
-# contribute to the log density (stochastic ones are forward-sampled, deterministic ones
-# recomputed, in post-processing), so the emitted code uses loop-index guards for
-# the surviving categories and lets generated-quantity iterations fall through. Returns
-# `nothing` when the whole statement is generated quantities.
+# Build a guard for `keep` iterations while keeping the emitted boolean expression short.
+# If the dropped set is smaller, guard on it and negate the condition.
+function __select_keep_condition(keep_loop_vars, drop_loop_vars)
+    if !isempty(drop_loop_vars) && length(drop_loop_vars) < length(keep_loop_vars)
+        return Expr(:call, :!, __generate_model_parameter_condition_expr(drop_loop_vars))
+    else
+        return __generate_model_parameter_condition_expr(keep_loop_vars)
+    end
+end
+
+# Lower a statement with generated-quantity iterations. Generated quantities are omitted
+# from the target; remaining iterations are guarded by loop index as needed.
 function __lower_stmt_with_generated_quantities(
-    statement, observed_loop_vars, model_parameter_loop_vars, deterministic_loop_vars
+    statement,
+    observed_loop_vars,
+    model_parameter_loop_vars,
+    generated_quantity_loop_vars,
+    deterministic_loop_vars,
 )
     if Meta.isexpr(statement, :call)
         # Stochastic `~` statement: keep model-parameter (`~`) and observed (`≂`) iterations.
@@ -360,6 +382,7 @@ function __lower_stmt_with_generated_quantities(
         tilde_stmt = MacroTools.@q $(lhs) ~ $(rhs)
         observe_stmt = MacroTools.@q $(lhs) ≂ $(rhs)
         if has_model_parameter && has_observed
+            # Omit the generated-quantity iterations by leaving no final else branch.
             return Expr(
                 :if,
                 __generate_model_parameter_condition_expr(model_parameter_loop_vars),
@@ -371,31 +394,41 @@ function __lower_stmt_with_generated_quantities(
                 ),
             )
         elseif has_model_parameter
+            # Keep `~` only where the variable remains a model parameter.
             return Expr(
                 :if,
-                __generate_model_parameter_condition_expr(model_parameter_loop_vars),
+                __select_keep_condition(
+                    model_parameter_loop_vars, generated_quantity_loop_vars
+                ),
                 Expr(:block, tilde_stmt),
             )
         elseif has_observed
+            # Keep `≂` only where the variable is observed.
             return Expr(
                 :if,
-                __generate_model_parameter_condition_expr(observed_loop_vars),
+                __select_keep_condition(observed_loop_vars, generated_quantity_loop_vars),
                 Expr(:block, observe_stmt),
             )
         else
             return nothing
         end
     else
-        # Deterministic `=` statement: keep the iterations that feed observations
-        # (transformed parameters); drop the generated-quantity ones.
+        # Deterministic generated quantities may be recomputed here because their values
+        # do not affect the target. Avoid the branch when dropped iterations are few;
+        # otherwise guard the kept deterministic iterations.
         if isempty(deterministic_loop_vars)
             return nothing
+        elseif length(generated_quantity_loop_vars) <= length(deterministic_loop_vars)
+            return statement
+        else
+            return Expr(
+                :if,
+                __select_keep_condition(
+                    deterministic_loop_vars, generated_quantity_loop_vars
+                ),
+                Expr(:block, statement),
+            )
         end
-        return Expr(
-            :if,
-            __generate_model_parameter_condition_expr(deterministic_loop_vars),
-            Expr(:block, statement),
-        )
     end
 end
 

--- a/JuliaBUGS/test/source_gen.jl
+++ b/JuliaBUGS/test/source_gen.jl
@@ -495,6 +495,24 @@ end
         )
     end
 
+    @testset "single statement mixes observed, parameter, and GQ iterations" begin
+        model = compile(
+            (@bugs begin
+                mu ~ Normal(0, 1)
+                for i in 1:3
+                    y[i] ~ Normal(mu, 1)
+                    z[i] ~ Normal(y[i], 1)
+                end
+            end),
+            (; y=[0.1, missing, missing], z=[missing, 0.2, missing]),
+        )
+
+        @test JuliaBUGS.variable_type(model, @varname(y[1])) == JuliaBUGS.Observation
+        @test JuliaBUGS.variable_type(model, @varname(y[2])) == JuliaBUGS.ModelParameter
+        @test JuliaBUGS.variable_type(model, @varname(y[3])) == JuliaBUGS.GeneratedQuantity
+        check_gq_invariants(model; n_params=2, n_gq=3, has_stochastic_gq=true)
+    end
+
     @testset "mixed loops (observed + parameter in x, observed + GQ in z)" begin
         # x[1], x[3] are parameters; x[2], x[4] observed; z[1], z[3] observed
         # likelihoods; z[2], z[4] are generated quantities.


### PR DESCRIPTION
## Summary

- add a direct source-generation regression for a single loop statement mixing observed, model-parameter, and generated-quantity iterations
- clarify the generated-quantity lowering comment around loop-index guards
- reduce generated source guard size by selecting the smaller kept/dropped iteration set, and avoid deterministic GQ branches when recomputation is cheaper than guarding