### PR TITLE
Document slice sampling and consolidate 0.15.0 changelog

### DIFF
--- a/JuliaBUGS/History.md
+++ b/JuliaBUGS/History.md
@@ -1,15 +1,5 @@
 # JuliaBUGS Changelog
 
-## Unreleased
-
-### Highlights
-
-- **Unified model construction (#383).** `@bugs` and `@bugs"..."` now return a callable `BUGSModelDef` instead of a bare `Expr`. Calling it with a data `NamedTuple` compiles the model, mirroring `@model`: `model = (@bugs begin … end)(data)` is equivalent to `compile(model_def, data)`. This makes `compile` an implementation detail rather than a required step.
-
-### Breaking Changes
-
-- `@bugs` / `@bugs"..."` now return a `BUGSModelDef` rather than an `Expr`. The underlying AST stays accessible via the `model_def` field, and `compile` still accepts the wrapper (and raw `Expr`s), so existing `compile(@bugs(...), data)` code — and serialization/source generation — is unaffected. Code that introspected the macro result *as* an `Expr` (e.g. `(@bugs ...).args`) should use `(@bugs ...).model_def`.
-
 ## 0.15.0
 
 ### Highlights
@@ -22,11 +12,16 @@
 
 - **FlexiChains support** (#483): Sampling can now collect results into a [`FlexiChains.FlexiChain{VarName}`](https://github.com/penelopeysm/FlexiChains.jl) by passing `chain_type=VNChain` (after `using FlexiChains`). Chains are keyed by `VarName`, so array-valued variables are stored whole instead of being flattened into scalar columns, and sampler statistics are stored as `FlexiChains.Extra` entries. This is the chain format the rest of the TuringLang ecosystem is moving to (Turing 0.45 uses it by default); the docs now use it in examples. `MCMCChains` remains fully supported via `chain_type=MCMCChains.Chains`, and a `FlexiChain` can be converted with `MCMCChains.Chains(chain)`.
 
+- **Slice sampling** ([SliceSampling.jl](https://github.com/TuringLang/SliceSampling.jl)): slice samplers can now sample `BUGSModel`s once `using SliceSampling`. They work standalone — pass a sampler such as `SliceSteppingOut` directly to `AbstractMCMC.sample` — and as component samplers inside `JuliaBUGS.Gibbs` (in the `sampler_map`), where each single-site conditional is univariate. Being derivative-free, they need no AD backend. Both `MCMCChains` (`chain_type=Chains`) and `FlexiChains` (`chain_type=VNChain`) outputs are supported, with sampler statistics (`lp`, `num_proposals`) recorded. Shipped as three package extensions mirroring the existing HMC/MH split. See the *Slice Sampling* page in the docs.
+
+- **Callable `@bugs` (#383).** `@bugs` and `@bugs"..."` now return a callable `BUGSModelDef` instead of a bare `Expr`, so a model builds in one step — `model = (@bugs begin … end)(data)` — mirroring `@model`. This is primarily a **syntax/ergonomics change**: `compile` still accepts the wrapper (and raw `Expr`s), so existing `compile(@bugs(...), data)` code, serialization, and source generation keep working unchanged, and the underlying AST stays available via the `.model_def` field. It makes `compile` an implementation detail rather than a required step.
+
 ### Breaking Changes
 
 - Unobserved stochastic nodes with **no observed descendants** (e.g. posterior-predictive draws, or priors unused by any likelihood) are now generated quantities: excluded from `model_parameters`, the parameter vector, and `LogDensityProblems.dimension`, and forward-sampled in post-processing instead of sampled by MCMC/Gibbs. The joint distribution is unchanged.
 - `parameters(model)` (all unobserved stochastic nodes) and `model_parameters(model)` (the MCMC target) can now differ, and `dimension` follows `model_parameters`. Use `LogDensityProblems.dimension(model)` (or `length(model_parameters(model))`) where you previously relied on `length(parameters(model))` as the parameter-vector length.
 - `Gibbs` sampler maps that reference a reclassified variable now error, since it is no longer in `model_parameters`.
+- The return type of `@bugs` / `@bugs"..."` changed from `Expr` to `BUGSModelDef` (#383). This is a low-impact, largely syntactic change (see the *Callable `@bugs`* highlight): the usual `compile(@bugs(...), data)` path, serialization, and source generation are unaffected. Only code that introspected the macro result *as* an `Expr` (e.g. `(@bugs ...).args`) must switch to the `.model_def` field.
 
 ## 0.14.1
 

--- a/JuliaBUGS/docs/Project.toml
+++ b/JuliaBUGS/docs/Project.toml
@@ -14,7 +14,9 @@ LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 MetaGraphsNext = "fa8bd995-216d-47f1-8a91-f3b68fbeb377"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+SliceSampling = "43f4d3e8-9711-4a8c-bd1b-03ac73a255cf"
 
 [sources]
 JuliaBUGS = {path = ".."}
@@ -23,3 +25,5 @@ JuliaBUGS = {path = ".."}
 Distributions = "0.25"
 Documenter = "1.14"
 FlexiChains = "0.6.14"
+OrderedCollections = "1, 2.0"
+SliceSampling = "0.7.11"

--- a/JuliaBUGS/docs/make.jl
+++ b/JuliaBUGS/docs/make.jl
@@ -23,6 +23,7 @@ makedocs(;
             "Auto-Marginalization" => "inference/auto_marginalization.md",
             "Generated Quantities" => "inference/generated_quantities.md",
             "Fixing Variables (`fix` / `unfix`)" => "inference/fixing.md",
+            "Slice Sampling" => "inference/slice_sampling.md",
             "Parallel & Distributed Sampling" => "inference/parallel.md",
         ],
         "API Reference" => [

--- a/JuliaBUGS/docs/src/inference/slice_sampling.md
+++ b/JuliaBUGS/docs/src/inference/slice_sampling.md
@@ -1,0 +1,116 @@
+# Slice Sampling
+
+[SliceSampling.jl](https://github.com/TuringLang/SliceSampling.jl) provides a family of
+**derivative-free** slice samplers. Once `using SliceSampling`, they can sample any compiled
+`BUGSModel`, so you get gradient-free inference without configuring an AD backend. This is handy
+for models with awkward geometry, non-differentiable pieces, or as a robust component sampler
+inside `JuliaBUGS.Gibbs`.
+
+Slice samplers are used two ways:
+
+- **Standalone** — pass a slice sampler to `AbstractMCMC.sample` to update the whole model.
+- **Inside `JuliaBUGS.Gibbs`** — assign a slice sampler to one or more variable groups in the
+  `sampler_map`; JuliaBUGS drives it through the Gibbs sweep.
+
+## Setup
+
+```@example slice
+using JuliaBUGS
+using JuliaBUGS: Gibbs
+using SliceSampling
+using AbstractMCMC
+using MCMCChains
+using OrderedCollections: OrderedDict
+
+model_def = @bugs begin
+    mu ~ dnorm(0, 0.0001)
+    y ~ dnorm(mu, 1)
+end
+model = model_def((; y = 1.5))
+```
+
+## Standalone sampling
+
+Univariate slice samplers such as `SliceSteppingOut` and `SliceDoublingOut` update one coordinate
+at a time. On a single-parameter model you can pass one directly:
+
+```@example slice
+chain = AbstractMCMC.sample(
+    model,
+    SliceSteppingOut(1.0),   # 1.0 is the initial slice window width
+    500;
+    chain_type = Chains,
+    progress = false,
+)
+summarystats(chain)
+```
+
+No `initial_params` is required: the extension implements `SliceSampling.initial_sample`, which
+seeds the sampler from the model's current parameter values.
+
+For a model with **more than one parameter**, wrap a univariate sampler in a multivariate
+strategy (e.g. `RandPermGibbs`, which cycles through coordinates in a random order), or use a
+genuinely multivariate slice sampler:
+
+```@example slice
+multi_def = @bugs begin
+    a ~ dnorm(0, 1)
+    b ~ dnorm(0, 1)
+    y ~ dnorm(a + b, 1)
+end
+multi_model = multi_def((; y = 0.5))
+
+multi_chain = AbstractMCMC.sample(
+    multi_model,
+    RandPermGibbs(SliceSteppingOut(1.0)),
+    500;
+    chain_type = Chains,
+    progress = false,
+)
+summarystats(multi_chain)
+```
+
+## Inside `Gibbs`
+
+Because each single-site conditional in `JuliaBUGS.Gibbs` is univariate, a bare univariate slice
+sampler works per site — no multivariate wrapper needed. Map variable groups to samplers in an
+`OrderedDict`:
+
+```@example slice
+sampler_map = OrderedDict(
+    @varname(a) => SliceSteppingOut(1.0),
+    @varname(b) => SliceSteppingOut(1.0),
+)
+gibbs = Gibbs(multi_model, sampler_map)
+
+gibbs_chain = AbstractMCMC.sample(
+    multi_model,
+    gibbs,
+    500;
+    chain_type = Chains,
+    progress = false,
+)
+summarystats(gibbs_chain)
+```
+
+Slice samplers can be freely mixed with other samplers (HMC, `IndependentMH`, …) in the same
+`sampler_map`.
+
+## Output formats and statistics
+
+Both chain backends are supported:
+
+- `chain_type = Chains` returns an `MCMCChains.Chains` (shown above).
+- `chain_type = VNChain` returns a [`FlexiChains.FlexiChain`](https://github.com/penelopeysm/FlexiChains.jl)
+  keyed by `VarName` (requires `using FlexiChains`):
+
+```julia
+using FlexiChains
+chain = AbstractMCMC.sample(model, SliceSteppingOut(1.0), 500; chain_type = VNChain, progress = false)
+```
+
+In either case the sampler's own statistics are recorded alongside the draws: the log density
+`lp` and `num_proposals` (the number of proposals the slice sampler evaluated per step). Under
+`MCMCChains` these appear as `internals`; under `FlexiChains` they are `FlexiChains.Extra`
+entries. For a multivariate sampler the per-coordinate `num_proposals` is flattened into
+`num_proposals[i]` columns for `MCMCChains`.


### PR DESCRIPTION
## Summary

Tidies the `0.15.0` changelog and documents the SliceSampling integration, which had landed in code (extensions + tests) but was not yet documented.

### Changelog (`History.md`)
- Fold the separate `Unreleased` section into `0.15.0`, so the whole release is described in one place.
- **Add a SliceSampling highlight** — the feature previously had no changelog entry. Covers standalone use, use within `Gibbs`, that it's derivative-free (no AD backend), `MCMCChains`/`FlexiChains` output, and the `lp`/`num_proposals` statistics.
- Move the callable `@bugs` / `BUGSModelDef` change into `0.15.0`, framed as a **syntax/ergonomics** change, with a scoped, low-impact note under Breaking Changes (only code that introspected the macro result as an `Expr` needs `.model_def`).

### Docs
- New page `docs/src/inference/slice_sampling.md` with runnable examples (standalone, multivariate via `RandPermGibbs`, and inside `Gibbs`) plus output-format/statistics notes; wired into the Inference nav.
- Add `SliceSampling` and `OrderedCollections` to the docs environment so the examples build.

### Verification
- `make.jl` builds cleanly with the new page and its runnable `@example` sampling blocks.
- Formatter run; no source formatting changes were needed for the touched files.