### PR TITLE
Fix T()/C() allowlist, dweib parameterization, and dt initialization

### DIFF
--- a/JuliaBUGS/History.md
+++ b/JuliaBUGS/History.md
@@ -1,6 +1,6 @@
 # JuliaBUGS Changelog
 
-## Unreleased
+## 0.16.1
 
 ### Bug Fixes
 

--- a/JuliaBUGS/History.md
+++ b/JuliaBUGS/History.md
@@ -1,5 +1,13 @@
 # JuliaBUGS Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- BUGS programs using truncation or censoring, `x ~ dnorm(0, 1)T(0, )` or `C(, c)`, compile out of the box. The string parser rewrites these to `truncated(...)` / `censored(...)`, which were missing from the default function allowlist, so `compile` rejected them unless the user registered both with `@bugs_primitive` first.
+- `dweib(a, b)` follows the BUGS parameterization, density `a b x^(a-1) exp(-b x^a)`, i.e. `Weibull(a, b^(-1/a))`. It previously built `Weibull(a, 1/b)`, which agrees only when `a = 1`. Posteriors of models with a Weibull likelihood and shape other than one (Mice, Kidney) change accordingly.
+- `x ~ dt(μ, τ, ν)` with a non-standard location or scale compiles without initial values: `TDistShiftedScaled` now implements `rand`, `minimum`, and `maximum`, which model construction and the unconstraining transform need.
+
 ## 0.16.0
 
 ### Highlights

--- a/JuliaBUGS/Project.toml
+++ b/JuliaBUGS/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaBUGS"
 uuid = "ba9fb4c0-828e-4473-b6a1-cd2560fee5bf"
-version = "0.16.0"
+version = "0.16.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/JuliaBUGS/src/BUGSPrimitives/distributions.jl
+++ b/JuliaBUGS/src/BUGSPrimitives/distributions.jl
@@ -41,7 +41,9 @@ This struct allows for a shift (determined by ``μ``) and a scale (determined by
 Student's t-distribution provided by the [Distributions.jl](https://github.com/JuliaStats/Distributions.jl) 
 package. 
 
-Only `pdf` and `logpdf` are implemented for this distribution.
+`pdf`, `logpdf`, `rand`, `minimum`, and `maximum` are implemented for this distribution; the
+last three are what a model needs to initialize a parameter with this prior and to transform it
+to unconstrained space.
 
 # See Also
 [TDist](https://juliastats.org/Distributions.jl/stable/univariate/#Distributions.TDist)
@@ -54,9 +56,15 @@ struct TDistShiftedScaled <: Distributions.ContinuousUnivariateDistribution
     TDistShiftedScaled(ν::Real, μ::Real, σ::Real) = new(ν, μ, σ)
 end
 
+Distributions.minimum(::TDistShiftedScaled) = -Inf
+Distributions.maximum(::TDistShiftedScaled) = Inf
+
 Distributions.pdf(d::TDistShiftedScaled, x::Real) = pdf(TDist(d.ν), (x - d.μ) / d.σ) / d.σ
 function Distributions.logpdf(d::TDistShiftedScaled, x::Real)
     return logpdf(TDist(d.ν), (x - d.μ) / d.σ) - log(d.σ)
+end
+function Base.rand(rng::Random.AbstractRNG, d::TDistShiftedScaled)
+    return d.μ + d.σ * rand(rng, TDist(d.ν))
 end
 
 """
@@ -220,7 +228,12 @@ end
     dweib(a, b)
 
 Returns an instance of [Weibull](https://juliastats.org/Distributions.jl/latest/univariate/#Distributions.Weibull) 
-distribution object with shape parameter ``a`` and scale parameter ``\\frac{1}{b}``.
+distribution object with shape parameter ``a`` and scale parameter ``b^{-1/a}``.
+
+BUGS parameterizes the Weibull by shape ``a`` and "rate-like" ``b`` (the density below), whereas
+`Distributions.Weibull(α, θ)` uses shape ``α`` and scale ``θ`` with density
+``\\frac{α}{θ} (x/θ)^{α-1} e^{-(x/θ)^α}``. Matching the two gives ``θ = b^{-1/a}``; the
+two agree with ``θ = 1/b`` only when ``a = 1``.
 
 The Weibull distribution is a common model for event times. The hazard or instantaneous risk of the event 
 is ``abx^{a-1}``. For ``a < 1`` the hazard decreases with ``x``; for ``a > 1`` it increases. 
@@ -231,7 +244,7 @@ p(x|a,b) = abx^{a-1}e^{-b x^a}
 ```
 """
 function dweib(a, b)
-    return Weibull(a, 1 / b)
+    return Weibull(a, b^(-1 / a))
 end
 
 """

--- a/JuliaBUGS/src/JuliaBUGS.jl
+++ b/JuliaBUGS/src/JuliaBUGS.jl
@@ -590,6 +590,12 @@ function __init__()
         push!(BUGS_ALLOWED_FUNCTIONS, func)
     end
 
+    # The string parser rewrites BUGS `T(l, u)` and `C(l, u)` to `truncated(...)` and
+    # `censored(...)`, so those must be allowed for such programs to compile.
+    for func in [:truncated, :censored]
+        push!(BUGS_ALLOWED_FUNCTIONS, func)
+    end
+
     # Add basic operators
     for op in [:+, :-, :*, :/, :^, :~, :>, :<, :>=, :<=, :(==), :!, :(:)]
         push!(BUGS_ALLOWED_FUNCTIONS, op)

--- a/JuliaBUGS/test/BUGSPrimitives/distributions.jl
+++ b/JuliaBUGS/test/BUGSPrimitives/distributions.jl
@@ -28,3 +28,36 @@ end
     ]
     LogDensityProblems.logdensity_and_gradient(ad_model, theta)
 end
+
+@testset "dweib matches the BUGS parameterization" begin
+    # BUGS: p(x | a, b) = a * b * x^(a-1) * exp(-b * x^a)
+    bugs_weibull_pdf(x, a, b) = a * b * x^(a - 1) * exp(-b * x^a)
+    for (a, b) in ((0.5, 2.0), (1.0, 3.0), (2.0, 3.0), (3.5, 0.2)), x in (0.1, 0.7, 2.5)
+        @test pdf(JuliaBUGS.dweib(a, b), x) ≈ bugs_weibull_pdf(x, a, b)
+    end
+    # a = 1 is the exponential distribution with rate b
+    @test pdf(JuliaBUGS.dweib(1.0, 3.0), 0.7) ≈ pdf(Exponential(1 / 3.0), 0.7)
+end
+
+@testset "dt with non-standard location/scale can be sampled" begin
+    using StableRNGs: StableRNG
+    using Statistics: median, quantile
+    d = JuliaBUGS.dt(1.0, 4.0, 3.0) # μ = 1, τ = 4 (σ = 1/2), ν = 3
+    @test d isa JuliaBUGS.BUGSPrimitives.TDistShiftedScaled
+    @test minimum(d) == -Inf && maximum(d) == Inf
+    rng = StableRNG(1)
+    xs = rand(rng, d, 200_000)
+    @test mean(xs) ≈ 1.0 atol = 0.02  # mean of a t with ν = 3 exists and equals μ
+    @test median(xs) ≈ 1.0 atol = 0.02
+    # standardizing recovers a standard t: compare an interquartile range
+    @test quantile((xs .- 1.0) ./ 0.5, 0.75) ≈ quantile(TDist(3.0), 0.75) atol = 0.03
+
+    # compiling a model with such a prior no longer needs initial values
+    model_def = @bugs begin
+        x ~ dt(1, 4, 3)
+    end
+    model = compile(model_def, NamedTuple())
+    @test model isa JuliaBUGS.BUGSModel
+    @test model.transformed_param_length == 1
+    @test isfinite(LogDensityProblems.logdensity(model, [0.3]))
+end

--- a/JuliaBUGS/test/parser/bugs_macro.jl
+++ b/JuliaBUGS/test/parser/bugs_macro.jl
@@ -245,6 +245,23 @@ end
         @test model isa JuliaBUGS.BUGSModel
     end
 
+    @testset "BUGS `T(,)` and `C(,)` compile without manual registration" begin
+        # The string parser rewrites `T(l, u)` / `C(l, u)` to `truncated` / `censored`;
+        # both must be in the default allowlist, or no program using them compiles.
+        @test :truncated in JuliaBUGS.BUGS_ALLOWED_FUNCTIONS
+        @test :censored in JuliaBUGS.BUGS_ALLOWED_FUNCTIONS
+
+        truncated_def = @bugs("model { x ~ dnorm(0, 1)T(0, ) }")
+        model = compile(truncated_def, NamedTuple())
+        @test model isa JuliaBUGS.BUGSModel
+        @test model.evaluation_env.x > 0
+
+        censored_def = @bugs("model { y ~ dnorm(0, 1)C(, c) }")
+        model = compile(censored_def, (c=0.5,))
+        @test model isa JuliaBUGS.BUGSModel
+        @test model.evaluation_env.y <= 0.5
+    end
+
     @testset "Qualified names in @bugs" begin
         # Test that qualified names are rejected in @bugs
         bugs_expr = @bugs begin

--- a/JuliaBUGS/test/runtests.jl
+++ b/JuliaBUGS/test/runtests.jl
@@ -47,7 +47,7 @@ using SliceSampling
 
 JuliaBUGS.@bugs_primitive Beta Bernoulli Categorical Exponential Gamma InverseGamma Normal Uniform LogNormal Poisson
 JuliaBUGS.@bugs_primitive Diagonal Dirichlet LKJ MvNormal
-JuliaBUGS.@bugs_primitive censored product_distribution truncated
+JuliaBUGS.@bugs_primitive product_distribution
 JuliaBUGS.@bugs_primitive fill ones zeros
 JuliaBUGS.@bugs_primitive sum mean sqrt
 


### PR DESCRIPTION
Three small, independent bug fixes in BUGS primitives and the default function allowlist. Each was found while auditing how BUGS syntax is supported and is reproduced on `main` below.

## 1. `T(,)` / `C(,)` programs could not compile

```julia
compile(@bugs("model { x ~ dnorm(0, 1)T(0, ) }"), (;))
# ERROR: Function 'truncated' is not allowed in @bugs ...
```

The string parser rewrites BUGS `T(l, u)` and `C(l, u)` to `truncated(...)` and `censored(...)`, but neither name was in `BUGS_ALLOWED_FUNCTIONS`. The test suite only passed because `test/runtests.jl` registered both with `@bugs_primitive`.

**Change:** add `:truncated` and `:censored` to the default allowlist in `__init__`; drop the manual registration in `runtests.jl` so tests exercise the default; add a test that compiles one `T()` and one `C()` string program.

## 2. `dweib(a, b)` used the wrong scale

BUGS defines `dweib(a, b)` by the density `a·b·x^(a-1)·exp(-b·x^a)` (this formula is also in the docstring). Matching it to `Distributions.Weibull(shape, scale)` gives `scale = b^(-1/a)`. The code used `Weibull(a, 1/b)`, which agrees only when `a = 1`:

```julia
pdf(dweib(2.0, 3.0), 0.7)        # main: 0.1532
2*3*0.7^(2-1)*exp(-3*0.7^2)      # BUGS: 0.9657
```

**Change:** `Weibull(a, b^(-1 / a))`, docstring explains the mapping, test checks the density against the BUGS formula over several `(a, b, x)` and the `a = 1` exponential special case. Note this changes the posterior of the shipped Mice and Kidney examples (Weibull likelihood with estimated shape `r`); they previously did not match the BUGS parameterization.

## 3. `x ~ dt(μ, τ, ν)` with μ ≠ 0 or τ ≠ 1 could not compile without inits

```julia
compile(@bugs(begin x ~ dt(1, 4, 3) end), (;))
# ERROR: MethodError: no method matching iterate(::TDistShiftedScaled)
```

`dt` returns the package's own `TDistShiftedScaled` in that case, which implemented only `pdf`/`logpdf`. `BUGSModel` construction calls `Bijectors.bijector(dist)` (needs `minimum`/`maximum`) and `rand(dist)` to initialize the parameter.

**Change:** implement `minimum`, `maximum`, and `rand(rng, d)` (`μ + σ·rand(TDist(ν))`). Test samples it, checks location/scale, and compiles the model above.

## Tests

`Pkg.test(test_args=["elementary", "frontend", "compilation_source_gen"])` passes locally (includes doctests and the source-gen checks on Mice/Kidney/Magnesium).
