### PR TITLE
Make Gibbs updates local to the Markov blanket

### DIFF
--- a/JuliaBUGS/History.md
+++ b/JuliaBUGS/History.md
@@ -1,5 +1,11 @@
 # JuliaBUGS Changelog
 
+## Unreleased
+
+### Improvements
+
+- **Gibbs updates are local to the Markov blanket.** The per-group model that `Gibbs` caches now evaluates only the nodes the group's full conditional depends on — the group, its stochastic children, and the deterministic nodes in between — instead of walking the whole graph with every other parameter conditioned on. Each update costs time proportional to the size of that set rather than to the size of the model; single-site sweeps over the Rats, Seeds and Epil examples run 5–20× faster with `IndependentMH` and up to 3× faster with slice sampling (whose own per-site overhead dominates on small models), and setup no longer copies the graph once per group. Conditionals are unchanged up to an additive constant, and gradients are identical. The building blocks are `JuliaBUGS.full_conditional_nodes(g, vs)` and `JuliaBUGS.Model.full_conditional_model(model, vs)`; `GraphEvaluationData` gained a `free_parameters` keyword that conditions on every other model parameter without copying the graph.
+
 ## 0.16.1
 
 ### Bug Fixes

--- a/JuliaBUGS/src/gibbs.jl
+++ b/JuliaBUGS/src/gibbs.jl
@@ -346,7 +346,8 @@ Initial step of the Gibbs sampler.
 
 This function initializes the Gibbs sampler by:
 1. Verifying the sampler map covers all parameters
-2. Creating conditioned models for each parameter group
+2. Creating the full-conditional model for each parameter group
+   (see [`JuliaBUGS.Model.full_conditional_model`](@ref))
 3. Initializing the sampler state
 
 # Returns
@@ -364,15 +365,16 @@ function AbstractMCMC.step(
     verify_sampler_map(model, sampler.sampler_map)
 
     cached_conditioned_models = OrderedDict()
-    model_parameters = model.graph_evaluation_data.model_parameters
+    node_positions = Model._node_positions(model)
 
     for variables_to_update in keys(sampler.sampler_map)
-        # Variables to condition on are all parameters except those we're updating
-        variables_to_condition_on = setdiff(model_parameters, variables_to_update)
-
-        # Create conditioned model
-        conditioned_model = AbstractPPL.condition(model, variables_to_condition_on)
-        cached_conditioned_models[variables_to_update] = conditioned_model
+        # The full conditional of the group given all other parameters. This conditions on
+        # every other parameter but only evaluates the nodes the conditional depends on
+        # (the group, its stochastic children, and the deterministic nodes in between), so
+        # an update costs O(size of that set) rather than O(size of the model).
+        cached_conditioned_models[variables_to_update] = Model.full_conditional_model(
+            model, variables_to_update; node_positions=node_positions
+        )
     end
     # Initialize sub_states as empty Dict
     sub_states = Dict{Any,Any}()

--- a/JuliaBUGS/src/graphs.jl
+++ b/JuliaBUGS/src/graphs.jl
@@ -168,3 +168,56 @@ function dfs_find_stochastic_boundary_and_deterministic_variables_en_route(
 
     return stochastic_neighbors, deterministic_variables_en_route
 end
+
+"""
+    full_conditional_nodes(g, vs)
+
+Return the set of nodes needed to evaluate the log full conditional density of the
+stochastic variables `vs` given every other variable in graph `g`, up to an additive
+constant.
+
+The log full conditional of `vs` is the sum of the log densities of `vs` themselves and of
+their stochastic children (the nodes whose distributions read `vs`, possibly through
+deterministic intermediates). Every other factor of the joint density is constant in `vs`.
+The returned set therefore contains `vs`, those stochastic children, and the deterministic
+nodes on the paths from `vs` to them — the nodes whose values or density terms change when
+`vs` changes. Parents and co-parents are read from the evaluation environment but are not
+included, since their densities do not depend on `vs`; this is the subset of
+[`markov_blanket`](@ref) that actually has to be evaluated.
+
+`vs` may be a single `VarName` or a collection of `VarName`s. For a collection, the search
+is run once with all of `vs` as sources, so a member of `vs` that is a child of another
+member is still only included once.
+"""
+function full_conditional_nodes(
+    g::MetaGraph{Int,<:SimpleDiGraph,L,VD}, vs::Union{AbstractVector{<:L},Tuple{Vararg{L}}}
+) where {L,VD}
+    for v in vs
+        if !is_stochastic(g, v)
+            throw(ArgumentError("Variable $v is logical, so it has no full conditional."))
+        end
+    end
+
+    nodes = Set{L}(vs)
+    # Walk forward from every source through deterministic nodes, stopping at the first
+    # stochastic node on each path. Sources start out visited: a source that is also a
+    # child of another source is already in `nodes` and on the stack.
+    visited = Set{L}(vs)
+    stack = L[v for v in vs]
+    while !isempty(stack)
+        current = pop!(stack)
+        for child in MetaGraphsNext.outneighbor_labels(g, current)
+            child in visited && continue
+            push!(visited, child)
+            push!(nodes, child)
+            if is_deterministic(g, child)
+                push!(stack, child)
+            end
+        end
+    end
+    return nodes
+end
+
+function full_conditional_nodes(g::MetaGraph{Int,<:SimpleDiGraph,L,VD}, v::L) where {L,VD}
+    return full_conditional_nodes(g, (v,))
+end

--- a/JuliaBUGS/src/model/abstractppl.jl
+++ b/JuliaBUGS/src/model/abstractppl.jl
@@ -808,6 +808,78 @@ function _create_modified_model(
     return BUGSModel(model; kwargs...)
 end
 
+"""
+    full_conditional_model(model::BUGSModel, variables; node_positions)
+
+Build the model whose log density is the log full conditional of `variables` given every
+other variable of `model`, up to an additive constant.
+
+The returned model conditions on all model parameters outside `variables` (its
+`model_parameters` are exactly `variables`, in `model`'s evaluation order), but unlike
+`AbstractPPL.condition` it evaluates only the nodes that the full conditional depends on:
+`variables`, their stochastic children, and the deterministic nodes on the paths between
+them (see [`JuliaBUGS.full_conditional_nodes`](@ref)). Every other node of the graph is
+neither evaluated nor scored, so the cost of one evaluation is proportional to the size of
+that set rather than to the size of the model. Generated quantities and fixed parameters
+are excluded, as they never contribute to the target density.
+
+Because parents and co-parents are read from the evaluation environment rather than
+recomputed, the environment must hold current values for them; this is the invariant that
+Gibbs sampling maintains by threading the updated environment through every update.
+
+`node_positions` maps each node of `model` to its index in
+`model.graph_evaluation_data.sorted_nodes`; pass a precomputed one when building many such
+models so that the total cost stays proportional to the summed set sizes. The
+`evaluation_mode` of the result is always `UseGraph()`.
+"""
+function full_conditional_model(
+    model::BUGSModel,
+    variables::AbstractVector{<:VarName};
+    node_positions::Dict{<:VarName,Int}=_node_positions(model),
+)
+    gd = model.graph_evaluation_data
+    for vn in variables
+        vn in gd.model_parameters ||
+            throw(ArgumentError("$vn is not a model parameter of the model"))
+    end
+
+    nodes = JuliaBUGS.full_conditional_nodes(model.g, variables)
+    filter!(nodes) do vn
+        variable_type = gd.variable_types[node_positions[vn]]
+        variable_type != GeneratedQuantity && variable_type != FixedParameter
+    end
+    sorted_nodes = sort!(collect(nodes); by=vn -> node_positions[vn])
+
+    new_graph_evaluation_data = GraphEvaluationData(
+        model.g,
+        sorted_nodes;
+        generated_quantities=Set{VarName}(gd.generated_quantities),
+        fixed_parameters=Set{VarName}(gd.fixed_parameters),
+        free_parameters=Set{VarName}(variables),
+    )
+    untransformed_param_length, transformed_param_length = _calculate_param_lengths(
+        model, new_graph_evaluation_data.model_parameters
+    )
+
+    return BUGSModel(
+        model;
+        untransformed_param_length=untransformed_param_length,
+        transformed_param_length=transformed_param_length,
+        graph_evaluation_data=new_graph_evaluation_data,
+        mutable_symbols=get_mutable_symbols(new_graph_evaluation_data),
+        base_model=isnothing(model.base_model) ? model : model.base_model,
+        # The restricted node list is only valid for graph evaluation.
+        evaluation_mode=UseGraph(),
+        log_density_computation_function=nothing,
+        marginalization_cache=nothing,
+    )
+end
+
+function _node_positions(model::BUGSModel)
+    sorted_nodes = model.graph_evaluation_data.sorted_nodes
+    return Dict{VarName,Int}(vn => i for (i, vn) in enumerate(sorted_nodes))
+end
+
 # Common helper function to regenerate log density function
 function _regenerate_log_density_function(
     model_def::Expr,

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -130,7 +130,7 @@ struct GraphEvaluationData{TNF,TV}
 end
 
 """
-    GraphEvaluationData(g::BUGSGraph, [sorted_nodes], [active_parameters]; [generated_quantities], [fixed_parameters])
+    GraphEvaluationData(g::BUGSGraph, [sorted_nodes], [active_parameters]; [generated_quantities], [fixed_parameters], [free_parameters])
 
 Create a `GraphEvaluationData` from a `BUGSGraph`, extracting and caching node information
 for efficient evaluation.
@@ -150,6 +150,15 @@ existing model.
 are removed from parameter lists and target-density scoring. Target-closure discovery
 treats them as barriers, so ancestors needed only to explain fixed variables can become
 generated quantities.
+
+`free_parameters`, when provided, conditions the evaluation data on every model parameter
+*not* in it: an unobserved stochastic node outside `free_parameters` that is neither a
+generated quantity nor a fixed parameter is recorded as observed, so evaluation scores it
+at its current environment value instead of reading it from the parameter vector. The
+resulting `model_parameters` are exactly the members of `free_parameters` found in
+`sorted_nodes`. This is the same classification `AbstractPPL.condition` produces, but
+without copying the graph, and its cost is proportional to `length(free_parameters)`
+rather than to the number of variables conditioned on.
 """
 function GraphEvaluationData(
     g::BUGSGraph,
@@ -159,6 +168,7 @@ function GraphEvaluationData(
     active_parameters::Union{Nothing,Vector{<:VarName}}=nothing;
     generated_quantities::Union{Nothing,Set{<:VarName}}=nothing,
     fixed_parameters::Set{<:VarName}=Set{VarName}(),
+    free_parameters::Union{Nothing,AbstractSet{<:VarName}}=nothing,
 )
     is_stochastic_vals = Array{Bool}(undef, length(sorted_nodes))
     is_observed_vals = Array{Bool}(undef, length(sorted_nodes))
@@ -201,6 +211,15 @@ function GraphEvaluationData(
 
     for (i, vn) in enumerate(sorted_nodes)
         (; is_stochastic, is_observed, node_function, loop_vars) = g[vn]
+        if free_parameters !== nothing &&
+            is_stochastic &&
+            !is_observed &&
+            vn ∉ free_parameters &&
+            vn ∉ fixed_parameter_vars &&
+            vn ∉ generated_quantity_vars
+            # Conditioned on: scored as an observation at its environment value.
+            is_observed = true
+        end
         is_stochastic_vals[i] = is_stochastic
         is_observed_vals[i] = is_observed
         node_function_vals[i] = node_function

--- a/JuliaBUGS/test/gibbs.jl
+++ b/JuliaBUGS/test/gibbs.jl
@@ -8,6 +8,9 @@ using Random
 using OrderedCollections: OrderedDict
 using MCMCChains: Chains
 using ReverseDiff
+using AbstractPPL
+using DifferentiationInterface
+using LogDensityProblems
 using Statistics
 using StatsBase: mode
 
@@ -479,6 +482,100 @@ using StatsBase: mode
                     env2.b != initial_params.b ||
                     env2.c != initial_params.c
             end
+        end
+
+        @testset "Full conditional models evaluate only the relevant nodes" begin
+            # The cached per-group models used by Gibbs are restricted to the group, its
+            # stochastic children, and the deterministic nodes in between. They must agree
+            # with conditioning the whole model up to an additive constant in the log
+            # density, and exactly in gradient, parameter layout, and updated environment.
+            (; model_def, data, inits) = JuliaBUGS.BUGSExamples.rats
+            model = compile(model_def, data, inits)
+            gd = model.graph_evaluation_data
+            node_positions = JuliaBUGS.Model._node_positions(model)
+            rng = Random.MersenneTwister(1)
+
+            groups = [
+                [@varname(alpha[7])],
+                [@varname(var"tau.c")],
+                [@varname(alpha[3]), @varname(beta[3])],
+                [@varname(var"alpha.c"), @varname(var"alpha.tau")],
+            ]
+            # alpha[7]: itself, mu[7, 1:5], Y[7, 1:5]
+            expected_sizes = [11, 1 + 150, 12, 2 + 30]
+            for (group, expected_size) in zip(groups, expected_sizes)
+                whole = AbstractPPL.condition(model, setdiff(gd.model_parameters, group))
+                sub = JuliaBUGS.Model.full_conditional_model(
+                    model, group; node_positions=node_positions
+                )
+                sub_gd = sub.graph_evaluation_data
+
+                @test length(sub_gd.sorted_nodes) == expected_size
+                # Parameters keep the model's evaluation order, not the group's order.
+                @test Set(sub_gd.model_parameters) == Set(group)
+                @test sub_gd.model_parameters ==
+                    whole.graph_evaluation_data.model_parameters
+                @test LogDensityProblems.dimension(sub) ==
+                    LogDensityProblems.dimension(whole)
+                @test isempty(sub_gd.generated_quantities)
+                @test sub.evaluation_mode isa JuliaBUGS.UseGraph
+                @test sub.base_model === model
+
+                θ0 = JuliaBUGS.getparams(sub)
+                @test θ0 == JuliaBUGS.getparams(whole)
+
+                # Same conditional up to an additive constant (the dropped factors).
+                offsets = map(1:5) do _
+                    θ = θ0 .+ randn(rng, length(θ0))
+                    LogDensityProblems.logdensity(whole, θ) -
+                    LogDensityProblems.logdensity(sub, θ)
+                end
+                @test all(o -> isapprox(o, offsets[1]; atol=1e-8), offsets)
+
+                # Identical gradients.
+                θ = θ0 .+ 0.1 .* randn(rng, length(θ0))
+                grad_whole = LogDensityProblems.logdensity_and_gradient(
+                    JuliaBUGS.BUGSModelWithGradient(whole, AutoReverseDiff()), θ
+                )[2]
+                grad_sub = LogDensityProblems.logdensity_and_gradient(
+                    JuliaBUGS.BUGSModelWithGradient(sub, AutoReverseDiff()), θ
+                )[2]
+                @test grad_sub ≈ grad_whole
+
+                # Writing parameters back leaves every variable of the model at the same
+                # value as the whole-graph conditioned model does.
+                env_whole = JuliaBUGS.initialize!(whole, θ).evaluation_env
+                env_sub = JuliaBUGS.initialize!(sub, θ).evaluation_env
+                for vn in gd.sorted_nodes
+                    @test AbstractPPL.getvalue(env_sub, vn) ≈
+                        AbstractPPL.getvalue(env_whole, vn)
+                end
+            end
+
+            @test_throws ArgumentError JuliaBUGS.Model.full_conditional_model(
+                model, [@varname(mu[1, 1])]
+            )
+            @test_throws ArgumentError JuliaBUGS.Model.full_conditional_model(
+                model, [@varname(Y[1, 1])]
+            )
+
+            # The Gibbs initial step caches exactly these restricted models.
+            gibbs = Gibbs(
+                model,
+                OrderedDict(
+                    [@varname(alpha[7])] => IndependentMH(),
+                    setdiff(gd.model_parameters, [@varname(alpha[7])]) => IndependentMH(),
+                ),
+            )
+            _, state = Base.invokelatest(
+                AbstractMCMC.step,
+                Random.MersenneTwister(2),
+                AbstractMCMC.LogDensityModel(model),
+                gibbs,
+            )
+            cached = state.cached_conditioned_models[[@varname(alpha[7])]]
+            @test length(cached.graph_evaluation_data.sorted_nodes) == 11
+            @test cached.graph_evaluation_data.model_parameters == [@varname(alpha[7])]
         end
     end
 

--- a/JuliaBUGS/test/graphs.jl
+++ b/JuliaBUGS/test/graphs.jl
@@ -1,5 +1,6 @@
 using JuliaBUGS:
     markov_blanket,
+    full_conditional_nodes,
     dfs_find_stochastic_boundary_and_deterministic_variables_en_route,
     find_generated_quantities_variables
 
@@ -101,6 +102,21 @@ end # module GraphsTest
         # - Deterministic nodes: f
         c = @varname c
         @test Set(Symbol.(markov_blanket(model.g, c))) == Set([:c, :l, :a, :b, :f])
+
+        # The full conditional of a node only needs the node, its stochastic children, and
+        # the deterministic nodes in between: parents (b via f, c) and co-parents (i) are
+        # read from the environment but not scored.
+        @test Set(Symbol.(full_conditional_nodes(g, a))) == Set([:a, :g, :d, :h, :e])
+        @test Set(Symbol.(full_conditional_nodes(g, c))) == Set([:c, :a])
+        # Leaf nodes only need themselves.
+        @test Set(Symbol.(full_conditional_nodes(g, @varname(d)))) == Set([:d])
+        # For a group, a member that is a child of another member is included once and its
+        # own children are still followed.
+        @test Set(Symbol.(full_conditional_nodes(g, [c, a]))) ==
+            Set([:c, :a, :g, :d, :h, :e])
+        @test Set(Symbol.(full_conditional_nodes(g, [a, l]))) ==
+            Set([:a, :g, :d, :h, :e, :l, :c])
+        @test_throws ArgumentError full_conditional_nodes(g, @varname(f))
     end
 
     @testset "Array variables and auxiliary nodes" begin


### PR DESCRIPTION
## What

`Gibbs` caches one conditioned model per parameter group. That model was built with `AbstractPPL.condition(model, setdiff(model_parameters, group))`, which conditions on the other parameters but leaves the node list intact — so every update still walked the entire graph, and setup copied the graph once per group.

The cached model now evaluates only the nodes the group's full conditional actually depends on:

```
p(B | rest) ∝ p(B | parents(B)) · ∏_{c ∈ children(B)} p(c | parents(c))
```

i.e. the group, its stochastic children, and the deterministic nodes on the paths in between. Parents and co-parents are read from the evaluation environment rather than recomputed — the invariant Gibbs already maintains by threading the updated environment through every update. Every other factor is constant in the group and cancels.

Updating `alpha[7]` in Rats now evaluates 11 nodes (itself, `mu[7, 1:5]`, `Y[7, 1:5]`) instead of all 367.

## How

- `JuliaBUGS.full_conditional_nodes(g, vs)` (`src/graphs.jl`) — forward walk from `vs` through deterministic nodes, stopping at the first stochastic node on each path. This is the subset of `markov_blanket` that has to be *evaluated*; `markov_blanket` itself was defined and tested but had no callers.
- `GraphEvaluationData` gains a `free_parameters` keyword (`src/model/bugsmodel.jl`) — an unobserved stochastic node outside the set that is neither a generated quantity nor a fixed parameter is recorded as observed, i.e. scored at its environment value. Same classification `condition` produces, without copying the graph, at cost proportional to the group size. Defaults to `nothing`, so existing callers are unaffected.
- `Model.full_conditional_model(model, vs; node_positions)` (`src/model/abstractppl.jl`) — assembles the restricted `GraphEvaluationData`, recomputes parameter lengths and `mutable_symbols`, clears caches, and pins `evaluation_mode` to `UseGraph()`. `node_positions` is computed once per sampler so building all groups' models stays proportional to the summed set sizes.
- `src/gibbs.jl` — the initial step calls it. The per-iteration step is untouched; all `gibbs_internal` implementations (IndependentMH, AdvancedHMC, AdvancedMH, SliceSampling) work unchanged because they only go through `sorted_nodes`.

## Correctness

For four Rats groups (single element, a hyperparameter with 150 children, two array elements, two scalars), tested against the whole-graph conditioned model:

- identical `model_parameters` and flat-vector layout, and identical `getparams`;
- log density equal **up to an additive constant** — the difference is constant across random parameter draws;
- **identical gradients** (ReverseDiff);
- `initialize!` leaves every variable in the model at the same value;
- exact node counts asserted (11 of 367 for `alpha[7]`), including that the Gibbs cache holds these restricted models.

Plus unit tests for `full_conditional_nodes` on the existing stub graph, covering leaf nodes, a group whose member is a child of another member, and the logical-node error.

Test groups run: `gibbs` (1592 tests), `graphs`, `compilation_model`, `model_operations`, `log_density`, `inference_mh`, `inference_slice_sampling`, `inference_hmc`, `callbacks` — all pass.

## Performance

Single-site sweeps, ms per sweep (all parameters updated once):

| model | sampler | main | this PR |
|---|---|---|---|
| Rats (367 nodes, 65 params) | IndependentMH | 6.43 | **1.00** |
| Rats | Slice | 14.82 | **5.05** |
| Seeds (69 nodes, 26 params) | IndependentMH | 1.39 | **0.27** |
| Seeds | Slice | 18.76 | 18.27 |
| Epil (781 nodes, 303 params) | IndependentMH | 110.2 | **4.73** |
| Epil | Slice | 199.3 | **104.0** |

Setup also drops (Epil 5.64s → 1.47s) since no graph is copied. Slice gains less because its own per-site `AbstractMCMC.step` / `LogDensityModel` / `initialize!` overhead dominates on small models — that, and `smart_copy_evaluation_env` still copying whole arrays (all of `mu` to update `alpha[7]`), are where the remaining overhead sits.

## Notes for review

1. The sub-model's `g` is the full, unconditioned graph; only `graph_evaluation_data` records the co-parameters as observed. This avoids one MetaGraph copy per group (O(G·N) setup, O(N²) for single-site). These models are internal Gibbs caches, but it does mean `is_observation(model.g, vn)` disagrees with `variable_type(model, vn)` on them.
2. Naming (`full_conditional_nodes` / `full_conditional_model` / `free_parameters`) is easy to change. Note the pre-existing `active_parameters` positional argument has different ("ignore, don't score") semantics and no callers; I left it alone.
3. Changelog entry is under `## Unreleased`.