### PR TITLE
inference: prepare AD models during sampling

### DIFF
--- a/JuliaBUGS/README.md
+++ b/JuliaBUGS/README.md
@@ -30,9 +30,9 @@ pkg> add AbstractMCMC ADTypes AdvancedHMC Distributions Mooncake
 
 ## Example
 
-The `@model` macro defines a model-building function. Its first argument lists stochastic
-variables; supplied values are observed and omitted values remain latent. Later arguments
-are fixed inputs.
+The `@model` macro defines a function that compiles a model when called. Its first argument
+declares every stochastic variable. Values supplied in that named tuple are observed;
+omitted values remain latent. Subsequent arguments are fixed inputs.
 
 ```julia
 using AbstractMCMC

--- a/JuliaBUGS/README.md
+++ b/JuliaBUGS/README.md
@@ -30,9 +30,9 @@ pkg> add AbstractMCMC ADTypes AdvancedHMC Distributions Mooncake
 
 ## Example
 
-The `@model` macro defines a function that compiles a model when called. Its first argument
-declares every stochastic variable. Values supplied in that named tuple are observed;
-omitted values remain latent. Subsequent arguments are fixed inputs.
+The `@model` macro defines a model-building function. Its first argument lists stochastic
+variables; supplied values are observed and omitted values remain latent. Later arguments
+are fixed inputs.
 
 ```julia
 using AbstractMCMC
@@ -52,14 +52,11 @@ end
 
 y = [1.2, 0.9, 1.4, 1.1, 0.7]
 model = normal_location((; y), 1.0, length(y))
-posterior = JuliaBUGS.BUGSModelWithGradient(
-    model, AutoMooncake(; config = nothing)
-)
-
 rng = MersenneTwister(42)
 sampler = HMC(0.1, 10)
 draws = sample(
-    rng, posterior, sampler, 2_000;
+    rng, model, sampler, 2_000;
+    adtype = AutoMooncake(; config = nothing),
     n_adapts = 500, discard_initial = 500, progress = false,
 )
 ```

--- a/JuliaBUGS/ext/JuliaBUGSAdvancedHMCExt.jl
+++ b/JuliaBUGS/ext/JuliaBUGSAdvancedHMCExt.jl
@@ -10,6 +10,17 @@ using JuliaBUGS.Random
 
 import JuliaBUGS: gibbs_internal
 
+function JuliaBUGS.Model._build_model(
+    ::BUGSModel, ::AdvancedHMC.AbstractHMCSampler, ::Nothing
+)
+    throw(
+        ArgumentError(
+            "Sampling with HMC or NUTS requires an explicit AD backend. " *
+            "Pass `adtype` to `sample`, or sample a `BUGSModelWithGradient`.",
+        ),
+    )
+end
+
 function JuliaBUGS.gibbs_internal(
     rng::Random.AbstractRNG,
     cond_model::BUGSModel,

--- a/JuliaBUGS/src/JuliaBUGS.jl
+++ b/JuliaBUGS/src/JuliaBUGS.jl
@@ -430,7 +430,10 @@ function compile(
             values(eval_env),
         ),
     )
-    base_model = BUGSModel(g, nonmissing_eval_env, model_def, data, initial_params, true)
+    compile_options = Model.ModelCompileOptions(skip_validation, eval_module)
+    base_model = BUGSModel(
+        g, nonmissing_eval_env, model_def, data, compile_options, initial_params, true
+    )
 
     # If adtype provided, wrap with gradient capabilities
     if adtype !== nothing

--- a/JuliaBUGS/src/gibbs.jl
+++ b/JuliaBUGS/src/gibbs.jl
@@ -355,9 +355,9 @@ This function initializes the Gibbs sampler by:
 """
 function AbstractMCMC.step(
     rng::Random.AbstractRNG,
-    l_model::AbstractMCMC.LogDensityModel{<:BUGSModel},
+    l_model::AbstractMCMC.LogDensityModel{<:Model.BUGSModelLike},
     sampler::Gibbs{N,S};
-    model=l_model.logdensity,
+    model=Model.base_bugs_model(l_model),
     kwargs...,
 ) where {N,S}
     # Verify sampler map on first step
@@ -402,10 +402,10 @@ For each group:
 """
 function AbstractMCMC.step(
     rng::Random.AbstractRNG,
-    l_model::AbstractMCMC.LogDensityModel{<:BUGSModel},
+    l_model::AbstractMCMC.LogDensityModel{<:Model.BUGSModelLike},
     sampler::Gibbs,
     state::AbstractGibbsState;
-    model=l_model.logdensity,
+    model=Model.base_bugs_model(l_model),
     kwargs...,
 )
     evaluation_env = state.evaluation_env

--- a/JuliaBUGS/src/independent_mh.jl
+++ b/JuliaBUGS/src/independent_mh.jl
@@ -50,12 +50,12 @@ end
 # Initial step
 function AbstractMCMC.step(
     rng::Random.AbstractRNG,
-    logdensitymodel::AbstractMCMC.LogDensityModel{<:BUGSModel},
+    logdensitymodel::AbstractMCMC.LogDensityModel{<:Model.BUGSModelLike},
     sampler::IndependentMH;
     initial_params=nothing,
     kwargs...,
 )
-    model = logdensitymodel.logdensity
+    model = Model.base_bugs_model(logdensitymodel)
 
     # Initialize with provided params or sample from prior
     if isnothing(initial_params)
@@ -74,12 +74,12 @@ end
 # Subsequent steps
 function AbstractMCMC.step(
     rng::Random.AbstractRNG,
-    logdensitymodel::AbstractMCMC.LogDensityModel{<:BUGSModel},
+    logdensitymodel::AbstractMCMC.LogDensityModel{<:Model.BUGSModelLike},
     sampler::IndependentMH,
     state::IndependentMHState;
     kwargs...,
 )
-    model = logdensitymodel.logdensity
+    model = Model.base_bugs_model(logdensitymodel)
 
     # Use smart copy for efficiency
     current_env = Model.smart_copy_evaluation_env(

--- a/JuliaBUGS/src/model/abstractmcmc.jl
+++ b/JuliaBUGS/src/model/abstractmcmc.jl
@@ -17,14 +17,14 @@ base_bugs_model(model::BUGSModel) = model
 base_bugs_model(model::BUGSModelWithGradient) = model.base_model
 base_bugs_model(model::AbstractMCMC.LogDensityModel) = base_bugs_model(model.logdensity)
 
-_build_model(model::BUGSModel, ::Nothing) = AbstractMCMC.LogDensityModel(model)
-function _build_model(model::BUGSModel, adtype::ADTypes.AbstractADType)
+_build_model(model::BUGSModel, ::Any, ::Nothing) = AbstractMCMC.LogDensityModel(model)
+function _build_model(model::BUGSModel, ::Any, adtype::ADTypes.AbstractADType)
     return AbstractMCMC.LogDensityModel(BUGSModelWithGradient(model, adtype))
 end
 
 function _prepare_and_sample(rng, model, sampler, args...; adtype, kwargs...)
     return AbstractMCMC.sample(
-        rng, _build_model(model, adtype), sampler, args...; kwargs...
+        rng, _build_model(model, sampler, adtype), sampler, args...; kwargs...
     )
 end
 

--- a/JuliaBUGS/src/model/abstractmcmc.jl
+++ b/JuliaBUGS/src/model/abstractmcmc.jl
@@ -17,10 +17,23 @@ base_bugs_model(model::BUGSModel) = model
 base_bugs_model(model::BUGSModelWithGradient) = model.base_model
 base_bugs_model(model::AbstractMCMC.LogDensityModel) = base_bugs_model(model.logdensity)
 
-_sampling_model(model::BUGSModel, ::Nothing) = AbstractMCMC.LogDensityModel(model)
-function _sampling_model(model::BUGSModel, adtype::ADTypes.AbstractADType)
+_build_model(model::BUGSModel, ::Nothing) = AbstractMCMC.LogDensityModel(model)
+function _build_model(model::BUGSModel, adtype::ADTypes.AbstractADType)
     return AbstractMCMC.LogDensityModel(BUGSModelWithGradient(model, adtype))
 end
+
+function _prepare_and_sample(rng, model, sampler, args...; adtype, kwargs...)
+    return AbstractMCMC.sample(
+        rng, _build_model(model, adtype), sampler, args...; kwargs...
+    )
+end
+
+# `compile` creates node functions with `Core.eval`, so models compiled and sampled
+# within one function cross a world-age boundary. Keep wrapping and sampling in one
+# `invokelatest` call. A future compiler should represent node expressions as callable
+# data, removing both `Core.eval` and this boundary.
+_sample_in_latest_world(args...; kwargs...) =
+    Base.invokelatest(_prepare_and_sample, args...; kwargs...)
 
 function AbstractMCMC.sample(
     rng::Random.AbstractRNG,
@@ -30,9 +43,7 @@ function AbstractMCMC.sample(
     adtype::Union{Nothing,ADTypes.AbstractADType}=nothing,
     kwargs...,
 )
-    return AbstractMCMC.sample(
-        rng, _sampling_model(model, adtype), sampler, N_or_isdone; kwargs...
-    )
+    return _sample_in_latest_world(rng, model, sampler, N_or_isdone; adtype, kwargs...)
 end
 
 function AbstractMCMC.sample(
@@ -45,8 +56,8 @@ function AbstractMCMC.sample(
     adtype::Union{Nothing,ADTypes.AbstractADType}=nothing,
     kwargs...,
 )
-    return AbstractMCMC.sample(
-        rng, _sampling_model(model, adtype), sampler, parallel, N, nchains; kwargs...
+    return _sample_in_latest_world(
+        rng, model, sampler, parallel, N, nchains; adtype, kwargs...
     )
 end
 

--- a/JuliaBUGS/src/model/abstractmcmc.jl
+++ b/JuliaBUGS/src/model/abstractmcmc.jl
@@ -17,6 +17,39 @@ base_bugs_model(model::BUGSModel) = model
 base_bugs_model(model::BUGSModelWithGradient) = model.base_model
 base_bugs_model(model::AbstractMCMC.LogDensityModel) = base_bugs_model(model.logdensity)
 
+_sampling_model(model::BUGSModel, ::Nothing) = AbstractMCMC.LogDensityModel(model)
+function _sampling_model(model::BUGSModel, adtype::ADTypes.AbstractADType)
+    return AbstractMCMC.LogDensityModel(BUGSModelWithGradient(model, adtype))
+end
+
+function AbstractMCMC.sample(
+    rng::Random.AbstractRNG,
+    model::BUGSModel,
+    sampler::AbstractMCMC.AbstractSampler,
+    N_or_isdone;
+    adtype::Union{Nothing,ADTypes.AbstractADType}=nothing,
+    kwargs...,
+)
+    return AbstractMCMC.sample(
+        rng, _sampling_model(model, adtype), sampler, N_or_isdone; kwargs...
+    )
+end
+
+function AbstractMCMC.sample(
+    rng::Random.AbstractRNG,
+    model::BUGSModel,
+    sampler::AbstractMCMC.AbstractSampler,
+    parallel::AbstractMCMC.AbstractMCMCEnsemble,
+    N::Integer,
+    nchains::Integer;
+    adtype::Union{Nothing,ADTypes.AbstractADType}=nothing,
+    kwargs...,
+)
+    return AbstractMCMC.sample(
+        rng, _sampling_model(model, adtype), sampler, parallel, N, nchains; kwargs...
+    )
+end
+
 # Strip the model wrappers once, so the per-format `gen_chains` methods only need a
 # `BUGSModel` method.
 function JuliaBUGS.gen_chains(

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -256,6 +256,9 @@ struct ModelCompileOptions
     eval_module::Module
 end
 
+# Compilation modules have global identity and stay shared across model copies.
+Base.deepcopy_internal(options::ModelCompileOptions, ::IdDict) = options
+
 """
     BUGSModel
 

--- a/JuliaBUGS/src/model/bugsmodel.jl
+++ b/JuliaBUGS/src/model/bugsmodel.jl
@@ -251,6 +251,11 @@ struct UseGeneratedLogDensityFunction <: EvaluationMode end
 struct UseGraph <: EvaluationMode end
 struct UseAutoMarginalization <: EvaluationMode end
 
+struct ModelCompileOptions
+    skip_validation::Bool
+    eval_module::Module
+end
+
 """
     BUGSModel
 
@@ -261,6 +266,7 @@ The `BUGSModel` object is used for inference and represents the output of compil
 
 - `model_def::Expr`: The original model definition (for serialization).
 - `data::data_T`: The data associated with the model (for serialization).
+- `compile_options::ModelCompileOptions`: Options needed to reconstruct node functions.
 - `g::BUGSGraph`: The dependency graph of the model.
 - `evaluation_env::T`: A `NamedTuple` containing values of variables in the model (constrained space).
 - `transformed::Bool`: Whether model parameters are in the transformed (unconstrained) space.
@@ -290,6 +296,7 @@ struct BUGSModel{
 } <: AbstractBUGSModel
     model_def::Expr
     data::data_T
+    compile_options::ModelCompileOptions
 
     g::BUGSGraph
 
@@ -332,11 +339,13 @@ function BUGSModel(
     mutable_symbols::Set{Symbol}=model.mutable_symbols,
     model_def::Expr=model.model_def,
     data=model.data,
+    compile_options::ModelCompileOptions=model.compile_options,
 )
     # Return model without precomputing caches (on-demand generation)
     return BUGSModel(
         model_def,
         data,
+        compile_options,
         g,
         evaluation_env,
         transformed,
@@ -402,6 +411,7 @@ function BUGSModel(
     evaluation_env::NamedTuple,
     model_def::Expr,
     data::NamedTuple,
+    compile_options::ModelCompileOptions,
     initial_params::NamedTuple=NamedTuple(),
     is_transformed::Bool=true,
 )
@@ -458,6 +468,7 @@ function BUGSModel(
     return BUGSModel(
         model_def,
         data,
+        compile_options,
         g,
         evaluation_env,
         is_transformed,

--- a/JuliaBUGS/src/model/logdensityproblems.jl
+++ b/JuliaBUGS/src/model/logdensityproblems.jl
@@ -109,12 +109,29 @@ grad_model = JuliaBUGS.BUGSModelWithGradient(model, AutoMooncake(; config=nothin
 ```
 """
 function BUGSModelWithGradient(model::BUGSModel, adtype::ADTypes.AbstractADType)
+    x = getparams(model)
+    _require_ad_integration(adtype, x)
+
     # Check AD backend compatibility with evaluation mode
     model = _check_ad_compatibility(model, adtype)
 
-    x = getparams(model)
     prep = _prepare_logdensity_gradient(adtype, model, x)
     return BUGSModelWithGradient(adtype, prep, model)
+end
+
+function _require_ad_integration(adtype::ADTypes.AbstractADType, x::AbstractVector)
+    applicable(AbstractPPL.prepare, adtype, _logdensity_for_gradient, x) && return nothing
+    if _is_mooncake(adtype)
+        requirement = "Mooncake"
+    else
+        requirement = "DifferentiationInterface and the package implementing the backend"
+    end
+    throw(
+        ArgumentError(
+            "No gradient implementation is loaded for $(typeof(adtype)). " *
+            "Load $requirement before constructing a `BUGSModelWithGradient`.",
+        ),
+    )
 end
 
 function _is_mooncake(adtype::ADTypes.AbstractADType)

--- a/JuliaBUGS/src/serialization.jl
+++ b/JuliaBUGS/src/serialization.jl
@@ -11,13 +11,17 @@ function Serialization.serialize(s::Serialization.AbstractSerializer, model::BUG
     Serialization.serialize(s, BUGSModel)
 
     # Serialize minimal state; skip generated functions and caches
-    Serialization.serialize(s, (
-        transformed = model.transformed,
-        model_def = model.model_def,
-        data = model.data,
-        evaluation_env = model.evaluation_env,
-        evaluation_mode = model.evaluation_mode
-    ))
+    Serialization.serialize(
+        s,
+        (
+            transformed=model.transformed,
+            model_def=model.model_def,
+            data=model.data,
+            evaluation_env=model.evaluation_env,
+            evaluation_mode=model.evaluation_mode,
+            compile_options=model.compile_options,
+        ),
+    )
     return nothing
 end
 
@@ -55,7 +59,14 @@ function Serialization.deserialize(s::Serialization.AbstractSerializer, ::Type{<
     state = Serialization.deserialize(s)
 
     # Reconstruct the model; compile regenerates process-local node functions.
-    model = compile(state.model_def, state.data, state.evaluation_env)
+    options = state.compile_options
+    model = compile(
+        state.model_def,
+        state.data,
+        state.evaluation_env;
+        skip_validation=options.skip_validation,
+        eval_module=options.eval_module,
+    )
     model = settrans(model, state.transformed)
 
     # Restore the original evaluation mode.

--- a/JuliaBUGS/test/ad_compatibility.jl
+++ b/JuliaBUGS/test/ad_compatibility.jl
@@ -224,4 +224,22 @@
             @test all(isfinite, grad)
         end
     end
+
+    @testset "Missing AD integration" begin
+        script = """
+        using ADTypes, JuliaBUGS
+        model = compile(@bugs(begin x ~ dnorm(0, 1) end), (;))
+        caught = try
+            JuliaBUGS.BUGSModelWithGradient(model, AutoReverseDiff())
+            nothing
+        catch exception
+            exception
+        end
+        @assert caught isa ArgumentError
+        @assert occursin("DifferentiationInterface", caught.msg)
+        """
+        run(
+            `$(Base.julia_cmd()) --project=$(Base.active_project()) --startup-file=no -e $script`,
+        )
+    end
 end

--- a/JuliaBUGS/test/distributed_sampling.jl
+++ b/JuliaBUGS/test/distributed_sampling.jl
@@ -15,9 +15,17 @@ addprocs(
     using DifferentiationInterface
     using ReverseDiff
     using StableRNGs
+    using Distributions
+
+    function assert_gradient_model(
+        rng, model, sampler, transition, state, iteration; kwargs...
+    )
+        @assert model.logdensity isa JuliaBUGS.BUGSModelWithGradient
+        return nothing
+    end
 end
 
-@testset "Distributed Sampling (Issue #333)" begin
+@testset "Distributed sampling" begin
     # Use the same model from issue #333
     data = (
         r=[10, 23, 23, 26, 17, 5, 53, 55, 32, 46, 10, 8, 10, 8, 23, 0, 3, 22, 15, 32, 3],
@@ -106,6 +114,31 @@ end
 
         @test length(samples) == n_chains
         @test all(length(chain) == n_samples for chain in samples)
+    end
+
+    @testset "MCMCDistributed prepares @model AD models" begin
+        @model function distributed_normal_model((; y, mu), sigma)
+            mu ~ Normal(0, 10)
+            y ~ Normal(mu, sigma)
+        end
+
+        model = distributed_normal_model((; y=1.0), 1.0)
+        n_chains = nworkers()
+        samples = sample(
+            StableRNG(1234),
+            model,
+            HMC(0.1, 2),
+            MCMCDistributed(),
+            2,
+            n_chains;
+            adtype=AutoReverseDiff(; compile=false),
+            callback=assert_gradient_model,
+            n_adapts=0,
+            progress=false,
+        )
+
+        @test length(samples) == n_chains
+        @test all(length(chain) == 2 for chain in samples)
     end
 end
 

--- a/JuliaBUGS/test/ext/JuliaBUGSAdvancedHMCExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSAdvancedHMCExt.jl
@@ -40,6 +40,22 @@
         @test all(chain -> length(chain) == 2, chains)
         @test length(callback_models) == 4
         @test all(is_ad_model, callback_models)
+
+        caught = try
+            AbstractMCMC.sample(
+                StableRNG(1234),
+                normal_location_hmc((; y=[1.2, 0.9, 1.4]), 1.0, 3),
+                HMC(0.1, 2),
+                1;
+                n_adapts=0,
+                progress=false,
+            )
+            nothing
+        catch exception
+            exception
+        end
+        @test caught isa ArgumentError
+        @test occursin("adtype", sprint(showerror, caught))
     end
 
     @testset "Generation of parameter names" begin

--- a/JuliaBUGS/test/ext/JuliaBUGSAdvancedHMCExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSAdvancedHMCExt.jl
@@ -1,4 +1,36 @@
 @testset "AdvancedHMC" begin
+    @testset "sample prepares the AD backend" begin
+        @model function normal_location_hmc((; y, mu), sigma, N)
+            mu ~ Normal(0, 10)
+            for i in 1:N
+                y[i] ~ Normal(mu, sigma)
+            end
+        end
+
+        model = normal_location_hmc((; y=[1.2, 0.9, 1.4]), 1.0, 3)
+        callback_models = Any[]
+        function callback(_, sampled_model, _, _, _, _; kwargs...)
+            return push!(callback_models, sampled_model.logdensity)
+        end
+
+        draws = AbstractMCMC.sample(
+            StableRNG(1234),
+            model,
+            HMC(0.1, 2),
+            3;
+            adtype=AutoReverseDiff(; compile=false),
+            callback=callback,
+            n_adapts=0,
+            progress=false,
+        )
+
+        @test length(draws) == length(callback_models) == 3
+        @test all(
+            m -> m isa JuliaBUGS.BUGSModelWithGradient && m.adtype isa AutoReverseDiff,
+            callback_models,
+        )
+    end
+
     @testset "Generation of parameter names" begin
         model_def = @bugs begin
             x[1:2] ~ dmnorm(mu[:], sigma[:, :])

--- a/JuliaBUGS/test/ext/JuliaBUGSAdvancedHMCExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSAdvancedHMCExt.jl
@@ -10,7 +10,9 @@
         function run_sampling(args...)
             model = normal_location_hmc((; y=[1.2, 0.9, 1.4]), 1.0, 3)
             callback_models = Any[]
-            function callback(_, sampled_model, _, _, _, _; kwargs...)
+            function callback(
+                rng, sampled_model, sampler, transition, state, iteration; kwargs...
+            )
                 return push!(callback_models, sampled_model.logdensity)
             end
             draws = AbstractMCMC.sample(

--- a/JuliaBUGS/test/ext/JuliaBUGSAdvancedHMCExt.jl
+++ b/JuliaBUGS/test/ext/JuliaBUGSAdvancedHMCExt.jl
@@ -1,5 +1,5 @@
 @testset "AdvancedHMC" begin
-    @testset "sample prepares the AD backend" begin
+    @testset "sample prepares AD models in function scope" begin
         @model function normal_location_hmc((; y, mu), sigma, N)
             mu ~ Normal(0, 10)
             for i in 1:N
@@ -7,28 +7,37 @@
             end
         end
 
-        model = normal_location_hmc((; y=[1.2, 0.9, 1.4]), 1.0, 3)
-        callback_models = Any[]
-        function callback(_, sampled_model, _, _, _, _; kwargs...)
-            return push!(callback_models, sampled_model.logdensity)
+        function run_sampling(args...)
+            model = normal_location_hmc((; y=[1.2, 0.9, 1.4]), 1.0, 3)
+            callback_models = Any[]
+            function callback(_, sampled_model, _, _, _, _; kwargs...)
+                return push!(callback_models, sampled_model.logdensity)
+            end
+            draws = AbstractMCMC.sample(
+                StableRNG(1234),
+                model,
+                HMC(0.1, 2),
+                args...;
+                adtype=AutoReverseDiff(; compile=false),
+                callback,
+                n_adapts=0,
+                progress=false,
+            )
+            return draws, callback_models
         end
 
-        draws = AbstractMCMC.sample(
-            StableRNG(1234),
-            model,
-            HMC(0.1, 2),
-            3;
-            adtype=AutoReverseDiff(; compile=false),
-            callback=callback,
-            n_adapts=0,
-            progress=false,
-        )
+        draws, callback_models = run_sampling(3)
+        is_ad_model =
+            m -> m isa JuliaBUGS.BUGSModelWithGradient && m.adtype isa AutoReverseDiff
 
         @test length(draws) == length(callback_models) == 3
-        @test all(
-            m -> m isa JuliaBUGS.BUGSModelWithGradient && m.adtype isa AutoReverseDiff,
-            callback_models,
-        )
+        @test all(is_ad_model, callback_models)
+
+        chains, callback_models = run_sampling(MCMCSerial(), 2, 2)
+        @test length(chains) == 2
+        @test all(chain -> length(chain) == 2, chains)
+        @test length(callback_models) == 4
+        @test all(is_ad_model, callback_models)
     end
 
     @testset "Generation of parameter names" begin

--- a/JuliaBUGS/test/gibbs.jl
+++ b/JuliaBUGS/test/gibbs.jl
@@ -242,6 +242,17 @@ using StatsBase: mode
             # `Gibbs` reports no statistics of its own, so the model's log density stands in.
             @test chain.name_map[:internals] == [:lp]
             @test all(isfinite, vec(chain[:lp].data))
+
+            draws = Base.invokelatest(
+                sample,
+                Random.MersenneTwister(123),
+                model,
+                gibbs,
+                2;
+                adtype=AutoReverseDiff(),
+                progress=false,
+            )
+            @test length(draws) == 2
         end
     end
 

--- a/JuliaBUGS/test/independent_mh.jl
+++ b/JuliaBUGS/test/independent_mh.jl
@@ -103,6 +103,23 @@ using Statistics
         @test isapprox(mean(theta_samples), 2.0, atol=0.1)
     end
 
+    @testset "Gradient-wrapped model" begin
+        model_def = @bugs begin
+            x ~ Normal(0, 1)
+        end
+        model = compile(model_def, (;))
+        draws = sample(
+            Random.MersenneTwister(123),
+            model,
+            IndependentMH(),
+            3;
+            adtype=ADTypes.AutoReverseDiff(),
+            progress=false,
+        )
+
+        @test length(draws) == 3
+    end
+
     @testset "IndependentMH state consistency" begin
         model_def = @bugs begin
             mu ~ Normal(0, 10)

--- a/JuliaBUGS/test/model/abstractmcmc.jl
+++ b/JuliaBUGS/test/model/abstractmcmc.jl
@@ -21,6 +21,18 @@ using Test
     sampler = IndependentMH()
     transition, state = AbstractMCMC.step(rng, logdensitymodel, sampler)
 
+    @testset "Function-scoped model construction" begin
+        function sample_in_function(model_def, data)
+            model = compile(model_def, data)
+            return sample(
+                Random.MersenneTwister(42), model, IndependentMH(), 3; progress=false
+            )
+        end
+
+        draws = sample_in_function(model_def, data)
+        @test length(draws) == 3
+    end
+
     @testset "ParamsWithStats with params only" begin
         pws = AbstractMCMC.ParamsWithStats(
             logdensitymodel, sampler, transition, state; params=true, stats=false

--- a/JuliaBUGS/test/model/bugsmodel.jl
+++ b/JuliaBUGS/test/model/bugsmodel.jl
@@ -33,6 +33,16 @@ end
     @test model.evaluation_env.x isa Vector{Float64}
 end
 
+@testset "Model compilation metadata can be deep-copied" begin
+    model_def = @bugs begin
+        x ~ dnorm(0, 1)
+    end
+    model = compile(model_def, (;))
+    copied = deepcopy(model)
+
+    @test copied.compile_options === model.compile_options
+end
+
 @testset "Model Interface Functions" begin
     @testset "parameters and variables" begin
         model_def = @bugs begin

--- a/JuliaBUGS/test/serialization.jl
+++ b/JuliaBUGS/test/serialization.jl
@@ -1,3 +1,22 @@
+serialization_normal(mu, sigma) = Normal(mu, sigma)
+
+@model function serialization_normal_model((; y, mu), sigma)
+    mu ~ serialization_normal(0, 10)
+    y ~ serialization_normal(mu, sigma)
+end
+
+@testset "serialization preserves @model compilation context" begin
+    model = serialization_normal_model((; y=1.0), 1.0)
+    io = IOBuffer()
+    serialize(io, model)
+    seekstart(io)
+    restored = deserialize(io)
+    params = JuliaBUGS.Model.getparams(model)
+
+    @test Base.invokelatest(LogDensityProblems.logdensity, restored, params) ==
+        Base.invokelatest(LogDensityProblems.logdensity, model, params)
+end
+
 @testset "serialization" begin
     (; model_def, data) = JuliaBUGS.BUGSExamples.rats
     model = compile(model_def, data)


### PR DESCRIPTION
`sample` now accepts a compiled model for gradient and gradient-free samplers. Passing `adtype` prepares the gradient wrapper internally; omitting it preserves gradient-free sampling.

```julia
using AbstractMCMC
using ADTypes: AutoMooncake
using AdvancedHMC: HMC
using Distributions: Normal
using JuliaBUGS
using Random
import Mooncake

@model function location((; y, μ), N)
    μ ~ Normal(0, 10)
    for i in 1:N
        y[i] ~ Normal(μ, 1)
    end
end

model = location((; y = [1.2, 0.9, 1.4]), 3)
rng = MersenneTwister(42)

hmc_draws = sample(
    rng, model, HMC(0.1, 5), 100;
    adtype = AutoMooncake(; config = nothing),
    n_adapts = 50,
    discard_initial = 50,
)

mh_draws = sample(rng, model, JuliaBUGS.IndependentMH(), 100)
```

The README now presents this simpler interface. Targeted HMC and IndependentMH tests pass.
