### PR TITLE
Redirect the old DoodleBUGS path to DoodlePPL

### DIFF
--- a/.github/workflows/DoodlePPLpublish.yml
+++ b/.github/workflows/DoodlePPLpublish.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'DoodlePPL/**'
+      - 'DoodleBUGS/**'
       - '.github/workflows/DoodlePPLpublish.yml'
   workflow_dispatch:
 
@@ -32,3 +33,14 @@ jobs:
           target-folder: DoodlePPL
           clean: true
           clean-exclude: pr-previews
+
+      # The pre-rename app is still deployed here and share links made before
+      # the rename point at it, so the path keeps serving a redirect. `clean`
+      # replaces that old build with the one page.
+      - name: Deploy the DoodleBUGS redirect
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: DoodleBUGS
+          target-folder: DoodleBUGS
+          clean: true

--- a/DoodleBUGS/index.html
+++ b/DoodleBUGS/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="https://turinglang.org/assets/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DoodlePPL</title>
+    <link rel="canonical" href="https://turinglang.org/JuliaBUGS.jl/DoodlePPL/" />
+    <!--
+      DoodleBUGS was renamed to DoodlePPL. Share links made before the rename
+      carry the graph in their own query string, so the redirect has to pass the
+      query and fragment along rather than just land on the new page.
+    -->
+    <script>
+      location.replace('../DoodlePPL/' + location.search + location.hash)
+    </script>
+    <noscript>
+      <meta http-equiv="refresh" content="0; url=../DoodlePPL/" />
+    </noscript>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        font-family: system-ui, sans-serif;
+        color: #333;
+      }
+    </style>
+  </head>
+  <body>
+    <p>DoodleBUGS is now <a href="../DoodlePPL/">DoodlePPL</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
`/JuliaBUGS.jl/DoodleBUGS/` still serves the pre-rename Vue app, because the publish step only ever writes `DoodlePPL/`. Every share link made before the rename points there, and until recently that was the only deployment able to open one, so the path cannot simply be deleted.

The path now serves a redirect that carries the query string and fragment across, which is what an old share link needs. A second deploy step with `clean` replaces the stale 2.3 MB build with that one page.

Draft until #535 raises the `doodleppl` pin. DoodlePPL is on `doodleppl@0.6`, which cannot read a share link, so redirecting before that lands would send old links somewhere strictly worse than where they go today.

Verified in Chrome: `/JuliaBUGS.jl/DoodleBUGS/?share=gz_ABC123#frag` lands on `/JuliaBUGS.jl/DoodlePPL/` with both the query and the fragment intact.